### PR TITLE
Cambiato parametro local_version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -53,7 +53,7 @@ install_monitor () {
 	if [[ ! -z "$local_version" ]]
 	then
             sed -i -e "s/^local_version=.*/local_version=$local_version/" /root/$1.sh
-	else [[ "$1" == "tendermint_monitor" ]]
+        elif [[ "$1" == "tendermint_monitor" ]]
 	    print_help
 	    exit 1
 	fi

--- a/install.sh
+++ b/install.sh
@@ -224,7 +224,7 @@ then
     then
         echo "It's in a docker container"
     else 	
-    	echo "[*] Installing substrate monitor..."
+    	echo "[*] Installing tendermint monitor..."
 	install_monitor "tendermint_monitor"
     	echo "[+] Installed tendermint monitor!"
 	echo "[*] Installing tendermint monitor..."

--- a/install.sh
+++ b/install.sh
@@ -54,6 +54,7 @@ install_monitor () {
 	then
             sed -i -e "s/^local_version=.*/local_version=$local_version/" /root/$1.sh
         elif [[ "$1" == "tendermint_monitor" ]]
+	then
 	    print_help
 	    exit 1
 	fi

--- a/install.sh
+++ b/install.sh
@@ -55,6 +55,9 @@ install_monitor () {
     if [[ ! -z "$local_version" ]]
     then
         sed -i -e "s/^local_version=.*/local_version=$local_version/" /root/$1.sh
+    elif [[ "$1" == "tendermint_monitor" ]]
+    then
+	echo "[-] No local release version specified, you will not receive any alerts about future release!"
     fi
     if [[ "$1" == "tendermint_monitor" && ! -z "$threshold_notsigned" && ! -z "$block_window" ]]
     then

--- a/install.sh
+++ b/install.sh
@@ -195,7 +195,6 @@ then
     exit 1
 fi
 
-install_monitor "substrate_monitor"
 rpc_substrate=$(lsof -i:$rpc_substrate_port)
 #check if we're dealing with a substrate based blockchain
 if [ ! -z "$rpc_substrate" ]

--- a/substrate_monitor.sh
+++ b/substrate_monitor.sh
@@ -12,7 +12,7 @@ stuck_e=$'\342\233\224'
 rel_e=$'\360\237\222\277'
 peers_down_e=$'\360\237\206\230'
 sync_e=$'\342\235\227'
-sync_ok_e=$'\342\243\205'
+sync_ok_e=$'\342\234\205'
 
 curl -s -X POST https://api.telegram.org/bot$api_token/sendMessage -d text="$name monitor started $start_e" -d chat_id=$chat_id
 

--- a/tendermint_monitor.sh
+++ b/tendermint_monitor.sh
@@ -22,7 +22,7 @@ block_e=$'\342\235\214'
 health_e=$'\360\237\232\250'
 peers_down_e=$'\360\237\206\230'
 sync_e=$'\342\235\227'
-sync_ok_e=$'\342\243\205'
+sync_ok_e=$'\342\234\205'
 
 curl -s -X POST https://api.telegram.org/bot$api_token/sendMessage -d text="$name monitor started $start_e" -d chat_id=$chat_id
 


### PR DESCRIPTION
Ho separato i flag `--git` e `--rel` (che indica la release installata in locale) in quanto quest'ultimo non è più strettamente necessario per il monitor delle chain substrate based (si riesce ad ottenerlo tramite query rpc), mentre andrebbe specificato se è usato il flag `--git` nelle chain tendermint based
close #8 