### PR TITLE
Solana Monitor custom tasks

### DIFF
--- a/srvcheck/chains/solana.py
+++ b/srvcheck/chains/solana.py
@@ -113,13 +113,27 @@ class TaskSolanaLeaderSchedule(Task):
 		except Exception:
 			return self.notify('no leader slot assigned for the epoch %s %s' % (ep, Emoji.NoLeader))
 
+class TaskSolanaSkippedSlots(Task):
+	def __init__(self, conf, notification, system, chain, checkEvery = hours(24), notifyEvery=hours(24)):
+		super().__init__('TaskSolanaSkippedSlots', conf, notification, system, chain, checkEvery, notifyEvery)
+
+	def isPluggable(conf):
+		return True
+
+	def run(self):
+		bp_info = self.chain.getBlockProduction()
+		skipped_perc = bp_info[1] / bp_info[0]
+		if skipped_perc > self.THRESHOLD_SKIPPED_SLOT:
+			return self.notify('skipped %d%% of assigned slots (%d/%d) %s' % (int(skipped_perc), bp_info[1], bp_info[0], Emoji.BlockMiss))
+		return False
+
 class Solana (Chain):
 	TYPE = "solana"
 	NAME = ""
 	BLOCKTIME = 60
 	THRESHOLD_SKIPPED_SLOT = 0.25 # 25 % 
 	EP = "http://localhost:8899/"
-	CUSTOM_TASKS = [ TaskSolanaHealthError, TaskSolanaDelinquentCheck, TaskSolanaBalanceCheck, TaskSolanaEpochActiveStake, TaskSolanaLeaderSchedule ]
+	CUSTOM_TASKS = [ TaskSolanaHealthError, TaskSolanaDelinquentCheck, TaskSolanaBalanceCheck, TaskSolanaEpochActiveStake, TaskSolanaLeaderSchedule, TaskSolanaSkippedSlots ]
 	
 	def __init__(self, conf):
 		super().__init__(conf)
@@ -153,8 +167,15 @@ class Solana (Chain):
 		identityAddr = self.getIdentityAddress()
 		schedule = self.rpcCall('getLeaderSchedule', [ None, { "identity": identityAddr } ])
 		if len(schedule) == 1:
-			return schedule[identityAddr]
+			return json.loads(schedule[identityAddr])
 		raise Exception('No leader slot assigned to your Identity for the current epoch')
+
+	def getBlockProduction(self):
+		identityAddr = self.getIdentityAddress()
+		b_prod_info = self.rpcCall('getBlockProduction', [ { "identity": identityAddr } ])['value']['byIdentity']
+		if len(b_prod_info) == 1:
+			return json.loads(b_prod_info[identityAddr])
+		raise Exception('No blocks produced in the current epoch')
 
 	def getPeerCount(self):
 		raise Exception('Abstract getPeerCount()')

--- a/srvcheck/chains/solana.py
+++ b/srvcheck/chains/solana.py
@@ -135,7 +135,7 @@ class Solana (Chain):
 	BLOCKTIME = 60
 	THRESHOLD_SKIPPED_SLOT = 0.25 # 25 % 
 	EP = "http://localhost:8899/"
-	CUSTOM_TASKS = [ TaskSolanaHealthError, TaskSolanaDelinquentCheck, TaskSolanaBalanceCheck, TaskSolanaEpochActiveStake, TaskSolanaLeaderSchedule, TaskSolanaSkippedSlots ]
+	CUSTOM_TASKS = [ TaskSolanaHealthError, TaskSolanaDelinquentCheck, TaskSolanaBalanceCheck, TaskSolanaLastVoteCheck, TaskSolanaEpochActiveStake, TaskSolanaLeaderSchedule, TaskSolanaSkippedSlots ]
 	
 	def __init__(self, conf):
 		super().__init__(conf)

--- a/srvcheck/chains/solana.py
+++ b/srvcheck/chains/solana.py
@@ -126,6 +126,13 @@ class Solana (Chain):
 	def getEpoch(self):
 		return self.rpcCall('getEpochInfo')['epoch']
 
+	def getLeaderSchedule(self):
+		identityAddr = self.getIdentityAddress()
+		schedule = self.rpcCall('getLeaderSchedule', [ None, { "identity": identityAddr } ])
+		if len(schedule) == 1:
+			return schedule[identityAddr]
+		raise Exception('No leader slot assigned to your Identity for the current epoch')
+
 	def getPeerCount(self):
 		raise Exception('Abstract getPeerCount()')
 

--- a/srvcheck/notification/notification.py
+++ b/srvcheck/notification/notification.py
@@ -23,6 +23,7 @@ class Emoji:
 	Delinq      = "\U0001F46E"
 	LowBal      = "\U0001F4B8"
 	ActStake    = "\U0001F37B"
+	NoLeader    = "\U0001F534"
 
 class Notification:
 	def __init__(self, name):

--- a/srvcheck/notification/notification.py
+++ b/srvcheck/notification/notification.py
@@ -22,6 +22,7 @@ class Emoji:
 	Proposal	= "\U0001f4e5"
 	Delinq      = "\U0001F46E"
 	LowBal      = "\U0001F4B8"
+	ActStake    = "\U0001F37B"
 
 class Notification:
 	def __init__(self, name):


### PR DESCRIPTION
Added custom tasks for **solana** monitoring:
- **`active stake`** report for each epoch (more or less 3 days)
- **`leader schedule`** monitoring that notifies if we are not in the leader schedule for each epoch
- **`block production`** and **`skip rate`** monitoring (alert if we skip the production of more than 25% of blocks for the slots assigned, for now it's a fixed threshold)