### PR TITLE
Tasks fixed

### DIFF
--- a/srvcheck/chains/tendermint.py
+++ b/srvcheck/chains/tendermint.py
@@ -56,16 +56,23 @@ class TaskTendermintNewProposal(Task):
 	def isPluggable(conf):
 		return True
 
+	def getProposalTitle(self, proposal):
+		if "id" in proposal:
+			return proposal["messages"][0]["content"]["title"]
+		elif "proposal_id" in proposal:
+			return proposal["content"]["title"]
+
 	def run(self):
 		nProposal = self.chain.getLatestProposal()
 		if not self.prev:
 			self.prev = nProposal
+			return self.notify(f'got latest proposal: {self.getProposalTitle(nProposal)} {Emoji.Proposal}')
 		elif "id" in self.prev and self.prev["id"] != nProposal["id"]:
 			self.prev = nProposal
-			return self.notify(f'got new proposal: {nProposal["messages"][0]["content"]["title"]} {Emoji.Proposal}')
+			return self.notify(f'got new proposal: {self.getProposalTitle(nProposal)} {Emoji.Proposal}')
 		elif "proposal_id" in self.prev and self.prev["proposal_id"] != nProposal["proposal_id"]:
 			self.prev = nProposal
-			return self.notify(f'got new proposal: {nProposal["content"]["title"]} {Emoji.Proposal}')
+			return self.notify(f'got new proposal: {self.getProposalTitle(nProposal)} {Emoji.Proposal}')
 		return False
 
 class TaskTendermintPositionChanged(Task):

--- a/srvcheck/tasks/tasknewrelease.py
+++ b/srvcheck/tasks/tasknewrelease.py
@@ -15,10 +15,10 @@ class TaskNewRelease(Task):
 	def run(self):
 		current = self.chain.getLocalVersion()
 		latest = self.chain.getLatestVersion()
-		c_ver = re.findall(r'(\d+[.]\d+[.]\d+)', current)[0]
-		l_ver = re.findall(r'(\d+[.]\d+[.]\d+)', latest)[0]
+		c_ver = int("".join(re.findall(r'(\d+[.]\d+[.]\d+)', current)[0].split('.')))
+		l_ver = int("".join(re.findall(r'(\d+[.]\d+[.]\d+)', latest)[0].split('.')))
 
-		if c_ver != l_ver:
+		if c_ver < l_ver:
 			output = f"has new release: {latest} {Emoji.Rel}"
 			if self.chain.TYPE == "solana":
 				d_stake = self.chain.getDelinquentStakePerc()


### PR DESCRIPTION
- Fixed `TaskNewRelease` previously if the version of the software installed on the server was higher than the latest release fetched from github api, we'd have received useless alerts
- Fixed `TaskTendermintNewProposal` previously the monitor wouldn't have sent the alert for the first proposal the monitor gets but only for the next ones after the first one