### PR TITLE
Fixed monitor issues

### DIFF
--- a/srvcheck/chains/substrate.py
+++ b/srvcheck/chains/substrate.py
@@ -1,13 +1,8 @@
-from calendar import c
 from substrateinterface import SubstrateInterface
-
-
 from srvcheck.tasks.task import hours
 from .chain import Chain
 from ..tasks import Task
 from ..notification import Emoji
-from ..utils import Bash
-
 
 class TaskSubstrateNewReferenda(Task):
 	def __init__(self, conf, notification, system, chain, checkEvery=hours(1), notifyEvery=60*10*60):
@@ -119,7 +114,6 @@ class Substrate (Chain):
 	def getRelayHeight(self):
 		c = self.rpcCall('chain_getBlock')['block']['extrinsics'][0]['method']['args']['data']['validationData']['relayParentNumber']
 		return c
-
 
 	def getParachainId(self):
 		si = self.getSubstrateInterface()

--- a/srvcheck/chains/substrate.py
+++ b/srvcheck/chains/substrate.py
@@ -112,8 +112,9 @@ class Substrate (Chain):
 		return abs(c['currentBlock'] - c['highestBlock']) > 32
 
 	def getRelayHeight(self):
-		c = self.rpcCall('chain_getBlock')['block']['extrinsics'][0]['method']['args']['data']['validationData']['relayParentNumber']
-		return c
+		si = self.getSubstrateInterface()
+		result = si.query(module='ParachainInfo', storage_function='ValidationData', params=[])
+		return result.value["relay_parent_number"]
 
 	def getParachainId(self):
 		si = self.getSubstrateInterface()

--- a/srvcheck/chains/substrate.py
+++ b/srvcheck/chains/substrate.py
@@ -113,7 +113,7 @@ class Substrate (Chain):
 
 	def getRelayHeight(self):
 		si = self.getSubstrateInterface()
-		result = si.query(module='ParachainInfo', storage_function='ValidationData', params=[])
+		result = si.query(module='ParachainSystem', storage_function='ValidationData', params=[])
 		return result.value["relay_parent_number"]
 
 	def getParachainId(self):

--- a/srvcheck/notification/telegramnotification.py
+++ b/srvcheck/notification/telegramnotification.py
@@ -2,6 +2,7 @@ import json
 import requests
 from ..utils.confset import ConfItem, ConfSet
 from .notificationprovider import NotificationProvider
+import urllib.parse
 
 ConfSet.addItem(ConfItem('notification.telegram.enabled', None, bool, 'enable telegram notification'))
 ConfSet.addItem(ConfItem('notification.telegram.apiToken', None, str, 'telegram api token'))
@@ -30,4 +31,4 @@ class TelegramNotification(NotificationProvider):
 			requests.get(f'https://api.telegram.org/bot{self.apiToken}/sendMessage?text={st}&chat_id={x}').json()
 
 	def format(self, name, string):
-		return '#' + name + ' ' + string
+		return urllib.parse.quote('#' + name + ' ' + string)

--- a/srvcheck/tasks/taskchainstuck.py
+++ b/srvcheck/tasks/taskchainstuck.py
@@ -43,7 +43,7 @@ class TaskChainStuck(Task):
 			return self.notify(f'chain is stuck at block {bh} since {elapsed} ({self.oc}) {Emoji.Stuck}')
 
 
-		if self.oc > 1:
+		if self.oc > 0:
 			elapsed = elapsedToString(self.since)
 			self.notify (f'chain come back in sync after {elapsed} ({self.oc}) {Emoji.SyncOk}')
 

--- a/tests/test-requirements.txt
+++ b/tests/test-requirements.txt
@@ -1,5 +1,5 @@
 requests
 pytest
 tox
-substrateinterface
+substrate-interface
 # coverage

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
 deps = 
     pytest
     requests
-    substrateinterface
+    substrate-interface
 commands =
     pytest 
     ; pytest --cov=srvcheck tests/


### PR DESCRIPTION
- Fixed substrate method **`getRelayHeight()`**, it wasn't working, we no longer use the rpc call because it has a strange encoding, but we now use the pallet `parachainSystem.validationData()` to get relay chain last block
- Changed tendermint custom tasks **`TaskTendermintBlockMissed`** to not alert us when we miss blocks when we are not in the active set
- Added alert to tendermint custom tasks **`TaskTendermintPositionChanged`** to alert us when we are out of the active set
- Fixed srvcheck dep on renamed module [`substrateinterface`](https://pypi.org/project/substrateinterface/#initialization), now we use [`substrate-interface`](https://pypi.org/project/substrate-interface/) instead
- Fixed **telegram** notification issue when there are special chars like `#`
- Fixed general task **`TaskChainStuck`**, it wouldn't alert us if the chain is no longer stuck if the `oc` was just one