### PR TITLE
Notify sw updated

### DIFF
--- a/srvcheck/chains/chain.py
+++ b/srvcheck/chains/chain.py
@@ -54,6 +54,15 @@ class Chain:
 			return c['tag_name']
 		raise Exception('No github repo specified!')
 
+	def getLocalVersion(self):
+		try:
+			return self.getVersion()
+		except Exception as e:
+			ver = self.conf.getOrDefault('chain.localVersion')
+			if ver is None:
+				raise Exception('No local version of the software specified!') from e
+			return ver
+
 	def getHeight(self):
 		""" Returns the block height """
 		raise Exception('Abstract getHeight()')

--- a/srvcheck/chains/lisk.py
+++ b/srvcheck/chains/lisk.py
@@ -27,7 +27,13 @@ class Lisk (Chain):
 		raise Exception('Abstract getLatestVersion()')
 
 	def getLocalVersion(self):
-		return self.getVersion()
+		try:
+			return self.getVersion()
+		except Exception as e:
+			ver = self.conf.getOrDefault('chain.localVersion')
+			if ver is None:
+				raise Exception('No local version of the software specified!') from e
+			return ver
 
 	def getVersion(self):
 		return self._nodeInfo()['version']

--- a/srvcheck/chains/lisk.py
+++ b/srvcheck/chains/lisk.py
@@ -26,15 +26,6 @@ class Lisk (Chain):
 	def getLatestVersion(self):
 		raise Exception('Abstract getLatestVersion()')
 
-	def getLocalVersion(self):
-		try:
-			return self.getVersion()
-		except Exception as e:
-			ver = self.conf.getOrDefault('chain.localVersion')
-			if ver is None:
-				raise Exception('No local version of the software specified!') from e
-			return ver
-
 	def getVersion(self):
 		return self._nodeInfo()['version']
 

--- a/srvcheck/chains/solana.py
+++ b/srvcheck/chains/solana.py
@@ -177,15 +177,6 @@ class Solana (Chain):
 	def getVersion(self):
 		return self.rpcCall('getVersion')["solana-core"]
 
-	def getLocalVersion(self):
-		try:
-			return self.getVersion()
-		except Exception as e:
-			ver = self.conf.getOrDefault('chain.localVersion')
-			if ver is None:
-				raise Exception('No local version of the software specified!') from e
-			return ver
-
 	def getHeight(self):
 		return self.rpcCall('getBlockHeight')
 

--- a/srvcheck/chains/solana.py
+++ b/srvcheck/chains/solana.py
@@ -178,7 +178,13 @@ class Solana (Chain):
 		return self.rpcCall('getVersion')["solana-core"]
 
 	def getLocalVersion(self):
-		return self.getVersion()
+		try:
+			return self.getVersion()
+		except Exception as e:
+			ver = self.conf.getOrDefault('chain.localVersion')
+			if ver is None:
+				raise Exception('No local version of the software specified!') from e
+			return ver
 
 	def getHeight(self):
 		return self.rpcCall('getBlockHeight')

--- a/srvcheck/chains/substrate.py
+++ b/srvcheck/chains/substrate.py
@@ -175,15 +175,6 @@ class Substrate (Chain):
 	def getVersion(self):
 		return self.rpcCall('system_version')
 
-	def getLocalVersion(self):
-		try:
-			return self.getVersion()
-		except Exception as e:
-			ver = self.conf.getOrDefault('chain.localVersion')
-			if ver is None:
-				raise Exception('No local version of the software specified!') from e
-			return ver
-
 	def getHeight(self):
 		return int(self.rpcCall('chain_getHeader', [self.getBlockHash()])['number'], 16)
 

--- a/srvcheck/chains/substrate.py
+++ b/srvcheck/chains/substrate.py
@@ -176,7 +176,13 @@ class Substrate (Chain):
 		return self.rpcCall('system_version')
 
 	def getLocalVersion(self):
-		return self.getVersion()
+		try:
+			return self.getVersion()
+		except Exception as e:
+			ver = self.conf.getOrDefault('chain.localVersion')
+			if ver is None:
+				raise Exception('No local version of the software specified!') from e
+			return ver
 
 	def getHeight(self):
 		return int(self.rpcCall('chain_getHeader', [self.getBlockHash()])['number'], 16)

--- a/srvcheck/chains/tezos.py
+++ b/srvcheck/chains/tezos.py
@@ -22,15 +22,6 @@ class Tezos (Chain):
 		a = self.getCall('version')
 		return f'v%s.%s.0' % (a['major'], a['minor'])
 
-	def getLocalVersion(self):
-		try:
-			return self.getVersion()
-		except Exception as e:
-			ver = self.conf.getOrDefault('chain.localVersion')
-			if ver is None:
-				raise Exception('No local version of the software specified!') from e
-			return ver
-
 	def getHeight(self):
 		return self.getCall('chains/main/blocks/head/helpers/current_level')['level']
 

--- a/srvcheck/chains/tezos.py
+++ b/srvcheck/chains/tezos.py
@@ -23,7 +23,13 @@ class Tezos (Chain):
 		return f'v%s.%s.0' % (a['major'], a['minor'])
 
 	def getLocalVersion(self):
-		return self.getVersion()
+		try:
+			return self.getVersion()
+		except Exception as e:
+			ver = self.conf.getOrDefault('chain.localVersion')
+			if ver is None:
+				raise Exception('No local version of the software specified!') from e
+			return ver
 
 	def getHeight(self):
 		return self.getCall('chains/main/blocks/head/helpers/current_level')['level']

--- a/srvcheck/main.py
+++ b/srvcheck/main.py
@@ -59,6 +59,7 @@ def main():
 	confRaw.read(cf)
 
 	conf = ConfSet(confRaw)
+	conf.addItem(ConfItem('configFile', cf, str))
 
 	# Get version
 	version = srvcheck.__version__

--- a/srvcheck/notification/notification.py
+++ b/srvcheck/notification/notification.py
@@ -31,6 +31,7 @@ class Emoji:
 	BlockProd   = "\U000026CF"
 	Slow	    = "\U0001f40c"
 	Unreachable = "\U0001f50c"
+	Updated     = "\U0001F4E2"
 
 class Notification:
 	def __init__(self, name):

--- a/srvcheck/tasks/tasknewrelease.py
+++ b/srvcheck/tasks/tasknewrelease.py
@@ -45,7 +45,7 @@ class TaskNewRelease(Task):
 		if self.conf.getOrDefault('chain.localVersion') is None:
 			return Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {current}/" {self.config_file}').value()
 
-		if versionCompare(self.conf.getOrDefault('chain.localVersion'), current) < 0:
+		if versionCompare(current, self.conf.getOrDefault('chain.localVersion')) > 0:
 			Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {current}/" {self.config_file}').value()
 			return self.notify(f'is now running latest version: {current}')
 		

--- a/srvcheck/tasks/tasknewrelease.py
+++ b/srvcheck/tasks/tasknewrelease.py
@@ -20,7 +20,7 @@ def versionCompare(current, latest):
 
 class TaskNewRelease(Task):
 	def __init__(self, conf, notification, system, chain):
-		super().__init__('TaskNewRelease', conf, notification, system, chain, minutes(15), hours(2))
+		super().__init__('TaskNewRelease', conf, notification, system, chain, minutes(3), hours(2))
 		self.conf = conf
 		self.cf = conf.getOrDefault('configFile')
 
@@ -32,6 +32,7 @@ class TaskNewRelease(Task):
 		current = self.chain.getLocalVersion()
 		latest = self.chain.getLatestVersion()
 
+		print('local', self.conf.getOrDefault('chain.localVersion'))
 		if self.conf.getOrDefault('chain.localVersion') is None:
 			Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {current}/" {self.cf}')
 			return False

--- a/srvcheck/tasks/tasknewrelease.py
+++ b/srvcheck/tasks/tasknewrelease.py
@@ -1,4 +1,5 @@
 import re
+import argparse
 from packaging import version
 from ..notification import Emoji
 from . import Task, minutes, hours
@@ -20,7 +21,11 @@ class TaskNewRelease(Task):
 	def __init__(self, conf, notification, system, chain):
 		super().__init__('TaskNewRelease', conf, notification, system, chain, minutes(15), hours(2))
 		self.conf = conf
-		self.config_file = "/etc/srvcheck.conf"
+		parser = argparse.ArgumentParser(description='Srvcheck helps you to monitor blockchain nodes.')
+		self.cf = "/etc/srvcheck.conf"
+		parser.add_argument('--config', type=str, default=self.cf, help='srvcheck config file')
+		args = parser.parse_args()
+		self.cf = args.config
 
 	@staticmethod
 	def isPluggable(conf, chain):
@@ -39,10 +44,10 @@ class TaskNewRelease(Task):
 			return self.notify(output)
 
 		if self.conf.getOrDefault('chain.localVersion') is None:
-			return Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {current.split("-")[0]}/" {self.config_file}').value()
+			return Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {current.split("-")[0]}/" {self.cf}').value()
 
 		if versionCompare(current, self.conf.getOrDefault('chain.localVersion')) > 0:
-			Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {current}/" {self.config_file}').value()
+			Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {current}/" {self.cf}').value()
 			return self.notify(f'is now running latest version: {current.split("-")[0]}')
 		
 		return False

--- a/srvcheck/tasks/tasknewrelease.py
+++ b/srvcheck/tasks/tasknewrelease.py
@@ -34,7 +34,10 @@ class TaskNewRelease(Task):
 	def run(self):
 		current = self.chain.getLocalVersion()
 		latest = self.chain.getLatestVersion()
-
+		
+		if self.conf.getOrDefault('chain.localVersion') is None:
+			Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {current}/" {self.cf}')
+		
 		if versionCompare(current, latest) < 0:
 			output = f"has new release: {latest} {Emoji.Rel}"
 			if self.chain.TYPE == "solana":
@@ -42,9 +45,6 @@ class TaskNewRelease(Task):
 				output += f"\n\tDelinquent Stake: {d_stake}%"
 				output += "\n\tIt's recommended to upgrade when there's less than 5% delinquent stake"
 			return self.notify(output)
-
-		if self.conf.getOrDefault('chain.localVersion') is None:
-			return Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {current}/" {self.cf}').value()
 
 		if versionCompare(current, self.conf.getOrDefault('chain.localVersion')) > 0:
 			Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {current}/" {self.cf}').value()

--- a/srvcheck/tasks/tasknewrelease.py
+++ b/srvcheck/tasks/tasknewrelease.py
@@ -1,6 +1,5 @@
 import re
 from packaging import version
-from srvcheck.main import main
 from ..notification import Emoji
 from . import Task, minutes, hours
 from ..utils import Bash

--- a/srvcheck/tasks/tasknewrelease.py
+++ b/srvcheck/tasks/tasknewrelease.py
@@ -1,10 +1,8 @@
-import re
 import argparse
 from packaging import version
 from ..notification import Emoji
 from . import Task, minutes, hours
 from ..utils import Bash
-
 
 def versionCompare(current, latest):
 	c_ver = version.parse(current.split('-')[0]) if isinstance(version.parse(current), version.LegacyVersion) is True else version.parse(current)
@@ -21,11 +19,7 @@ class TaskNewRelease(Task):
 	def __init__(self, conf, notification, system, chain):
 		super().__init__('TaskNewRelease', conf, notification, system, chain, minutes(15), hours(2))
 		self.conf = conf
-		parser = argparse.ArgumentParser(description='Srvcheck helps you to monitor blockchain nodes.')
-		self.cf = "/etc/srvcheck.conf"
-		parser.add_argument('--config', type=str, default=self.cf, help='srvcheck config file')
-		args = parser.parse_args()
-		self.cf = args.config
+		self.cf = conf.getOrDefault('configFile')
 
 	@staticmethod
 	def isPluggable(conf, chain):
@@ -34,7 +28,7 @@ class TaskNewRelease(Task):
 	def run(self):
 		current = self.chain.getLocalVersion()
 		latest = self.chain.getLatestVersion()
-		
+
 		if self.conf.getOrDefault('chain.localVersion') is None:
 			Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {current}/" {self.cf}')
 		
@@ -47,7 +41,7 @@ class TaskNewRelease(Task):
 			return self.notify(output)
 
 		if versionCompare(current, self.conf.getOrDefault('chain.localVersion')) > 0:
-			Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {current}/" {self.cf}').value()
+			Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {current}/" {self.cf}')
 			return self.notify(f'is now running latest version: {current.split("-")[0]} {Emoji.Updated}')
 		
 		return False

--- a/srvcheck/tasks/tasknewrelease.py
+++ b/srvcheck/tasks/tasknewrelease.py
@@ -40,7 +40,7 @@ class TaskNewRelease(Task):
 				output += "\n\tIt's recommended to upgrade when there's less than 5% delinquent stake"
 			return self.notify(output)
 
-		if versionCompare(current, self.conf.getOrDefault('chain.localVersion')) > 0:
+		if versionCompare(current, latest) > 0:
 			Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {current}/" {self.cf}')
 			return self.notify(f'is now running latest version: {current.split("-")[0]} {Emoji.Updated}')
 		

--- a/srvcheck/tasks/tasknewrelease.py
+++ b/srvcheck/tasks/tasknewrelease.py
@@ -1,4 +1,3 @@
-import argparse
 from packaging import version
 from ..notification import Emoji
 from . import Task, minutes, hours
@@ -35,9 +34,9 @@ class TaskNewRelease(Task):
 
 		if self.conf.getOrDefault('chain.localVersion') is None:
 			Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {current}/" {self.cf}')
+			return False
 		
 		print(current, latest)
-		print(versionCompare(current, latest))
 		if versionCompare(current, latest) < 0:
 			output = f"has new release: {latest} {Emoji.Rel}"
 			if self.chain.TYPE == "solana":
@@ -46,7 +45,7 @@ class TaskNewRelease(Task):
 				output += "\n\tIt's recommended to upgrade when there's less than 5% delinquent stake"
 			return self.notify(output)
 
-		print(current, self.conf.getOrDefault('chain.localVersion'))
+		print('current, chain.localVersion', current, self.conf.getOrDefault('chain.localVersion'))
 		print(versionCompare(current, self.conf.getOrDefault('chain.localVersion')))
 		if versionCompare(current, self.conf.getOrDefault('chain.localVersion')) > 0:
 			Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {current}/" {self.cf}')

--- a/srvcheck/tasks/tasknewrelease.py
+++ b/srvcheck/tasks/tasknewrelease.py
@@ -43,7 +43,7 @@ class TaskNewRelease(Task):
 			return self.notify(output)
 
 		if self.conf.getOrDefault('chain.localVersion') is None:
-			return Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {current}/" {self.config_file}').value()
+			return Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {current.split("-")[0]}/" {self.config_file}').value()
 
 		if versionCompare(current, self.conf.getOrDefault('chain.localVersion')) > 0:
 			Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {current}/" {self.config_file}').value()

--- a/srvcheck/tasks/tasknewrelease.py
+++ b/srvcheck/tasks/tasknewrelease.py
@@ -5,12 +5,9 @@ from . import Task, minutes, hours
 from ..utils import Bash
 
 
-def versionCompare(current, latest, prerelease=False):
-	c_ver = version.parse(current.split('-')[0])
-	if prerelease:
-		l_ver = version.parse(latest.split('-')[0])
-	else: # ignore prerelease
-		l_ver = version.parse(latest)
+def versionCompare(current, latest):
+	c_ver = version.parse(current.split('-')[0]) if isinstance(version.parse(current), version.LegacyVersion) is True else version.parse(current)
+	l_ver = version.parse(latest.split('-')[0]) if isinstance(version.parse(latest), version.LegacyVersion) is True else version.parse(latest)
 
 	if c_ver < l_ver:
 		return -1

--- a/srvcheck/tasks/tasknewrelease.py
+++ b/srvcheck/tasks/tasknewrelease.py
@@ -44,7 +44,7 @@ class TaskNewRelease(Task):
 			return self.notify(output)
 
 		if self.conf.getOrDefault('chain.localVersion') is None:
-			return Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {current.split("-")[0]}/" {self.cf}').value()
+			return Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {current}/" {self.cf}').value()
 
 		if versionCompare(current, self.conf.getOrDefault('chain.localVersion')) > 0:
 			Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {current}/" {self.cf}').value()

--- a/srvcheck/tasks/tasknewrelease.py
+++ b/srvcheck/tasks/tasknewrelease.py
@@ -47,6 +47,6 @@ class TaskNewRelease(Task):
 
 		if versionCompare(current, self.conf.getOrDefault('chain.localVersion')) > 0:
 			Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {current}/" {self.config_file}').value()
-			return self.notify(f'is now running latest version: {current}')
+			return self.notify(f'is now running latest version: {current.split("-")[0]}')
 		
 		return False

--- a/srvcheck/tasks/tasknewrelease.py
+++ b/srvcheck/tasks/tasknewrelease.py
@@ -48,6 +48,6 @@ class TaskNewRelease(Task):
 
 		if versionCompare(current, self.conf.getOrDefault('chain.localVersion')) > 0:
 			Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {current}/" {self.cf}').value()
-			return self.notify(f'is now running latest version: {current.split("-")[0]}')
+			return self.notify(f'is now running latest version: {current.split("-")[0]} {Emoji.Updated}')
 		
 		return False

--- a/srvcheck/tasks/tasknewrelease.py
+++ b/srvcheck/tasks/tasknewrelease.py
@@ -48,6 +48,7 @@ class TaskNewRelease(Task):
 
 		if versionCompare(current, self.conf.getOrDefault('chain.localVersion')) > 0:
 			Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {current}/" {self.cf}')
-			return self.notify(f'is now running latest version: {current.split("-")[0]} {Emoji.Updated}')
+			self.notify(f'is now running latest version: {current.split("-")[0]} {Emoji.Updated}')
+			self.notification.flush()
 		
 		return False

--- a/srvcheck/tasks/tasknewrelease.py
+++ b/srvcheck/tasks/tasknewrelease.py
@@ -5,6 +5,10 @@ from . import Task, minutes, hours
 from ..utils import Bash
 
 def versionCompare(current, latest):
+	print(current, current.split('-'))
+	print(latest, latest.split('-'))
+	print(version.parse(current))
+	print(version.parse(latest))
 	c_ver = version.parse(current.split('-')[0]) if isinstance(version.parse(current), version.LegacyVersion) is True else version.parse(current)
 	l_ver = version.parse(latest.split('-')[0]) if isinstance(version.parse(latest), version.LegacyVersion) is True else version.parse(latest)
 
@@ -32,6 +36,8 @@ class TaskNewRelease(Task):
 		if self.conf.getOrDefault('chain.localVersion') is None:
 			Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {current}/" {self.cf}')
 		
+		print(current, latest)
+		print(versionCompare(current, latest))
 		if versionCompare(current, latest) < 0:
 			output = f"has new release: {latest} {Emoji.Rel}"
 			if self.chain.TYPE == "solana":
@@ -40,6 +46,8 @@ class TaskNewRelease(Task):
 				output += "\n\tIt's recommended to upgrade when there's less than 5% delinquent stake"
 			return self.notify(output)
 
+		print(current, self.conf.getOrDefault('chain.localVersion'))
+		print(versionCompare(current, self.conf.getOrDefault('chain.localVersion')))
 		if versionCompare(current, self.conf.getOrDefault('chain.localVersion')) > 0:
 			Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {current}/" {self.cf}')
 			return self.notify(f'is now running latest version: {current.split("-")[0]} {Emoji.Updated}')

--- a/srvcheck/tasks/tasknewrelease.py
+++ b/srvcheck/tasks/tasknewrelease.py
@@ -40,7 +40,7 @@ class TaskNewRelease(Task):
 				output += "\n\tIt's recommended to upgrade when there's less than 5% delinquent stake"
 			return self.notify(output)
 
-		if versionCompare(current, latest) > 0:
+		if versionCompare(current, self.conf.getOrDefault('chain.localVersion')) > 0:
 			Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {current}/" {self.cf}')
 			return self.notify(f'is now running latest version: {current.split("-")[0]} {Emoji.Updated}')
 		

--- a/srvcheck/tasks/tasknewrelease.py
+++ b/srvcheck/tasks/tasknewrelease.py
@@ -23,6 +23,8 @@ class TaskNewRelease(Task):
 		super().__init__('TaskNewRelease', conf, notification, system, chain, minutes(3), hours(2))
 		self.conf = conf
 		self.cf = conf.getOrDefault('configFile')
+		if self.conf.getOrDefault('chain.localVersion') is None:
+			Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {self.chain.getLocalVersion()}/" {self.cf}')
 
 	@staticmethod
 	def isPluggable(conf, chain):

--- a/srvcheck/tasks/tasknewrelease.py
+++ b/srvcheck/tasks/tasknewrelease.py
@@ -1,7 +1,8 @@
+import configparser
 from packaging import version
 from ..notification import Emoji
 from . import Task, minutes, hours
-from ..utils import Bash
+from ..utils import Bash, ConfSet, ConfItem
 
 def versionCompare(current, latest):
 	print(current, current.split('-'))
@@ -23,14 +24,17 @@ class TaskNewRelease(Task):
 		super().__init__('TaskNewRelease', conf, notification, system, chain, minutes(3), hours(2))
 		self.conf = conf
 		self.cf = conf.getOrDefault('configFile')
-		if self.conf.getOrDefault('chain.localVersion') is None:
-			Bash(f'sed -i -e "s/^localVersion =.*/localVersion = {self.chain.getLocalVersion()}/" {self.cf}')
 
 	@staticmethod
 	def isPluggable(conf, chain):
 		return True if conf.getOrDefault('chain.ghRepository') else False
 
 	def run(self):
+		confRaw = configparser.ConfigParser()
+		confRaw.optionxform=str
+		confRaw.read(self.cf)
+		self.conf = ConfSet(confRaw)
+		
 		current = self.chain.getLocalVersion()
 		latest = self.chain.getLatestVersion()
 

--- a/tests/task_test.py
+++ b/tests/task_test.py
@@ -1,8 +1,9 @@
 import unittest
+import configparser
 import urllib.parse
 
 from srvcheck.tasks.tasknewrelease import TaskNewRelease, versionCompare
-from srvcheck.utils.confset import ConfSet
+from srvcheck.utils.confset import ConfItem, ConfSet
 from srvcheck.tasks import TaskChainLowPeer, TaskChainStuck, TaskSystemCpuAlert, TaskSystemDiskAlert, minutes, hours
 from srvcheck.notification.notification import Emoji
 from .mocks import MockNotification, MockChain, MockSystem, MockChainNoBlockHash
@@ -122,6 +123,24 @@ class TestTaskChainStuck(unittest.TestCase):
 
 
 class TestTaskNewRelease(unittest.TestCase):
+	CONF = {
+		'chain': {
+			'name': 'test',
+			'endpoint': 'http://localhost:8080',
+			'type': '',
+			'blockTime': 10,
+			'service': '',
+			'activeSet': '',
+			'localVersion': 'v0.0.1'
+		}
+	}
+
+	confRaw = configparser.ConfigParser()
+	confRaw.optionxform=str
+	confRaw.read_dict(CONF)
+
+	conf = ConfSet(confRaw)
+
 	def test_VersionCompare(self):
 		self.assertEqual(versionCompare('v1.0.0', 'v1.0.0'), 0)
 		self.assertEqual(versionCompare('v1.0.0', 'v1.0.1'), -1)
@@ -131,7 +150,7 @@ class TestTaskNewRelease(unittest.TestCase):
 
 	def test_noalert(self):
 		c, n, t, s = buildTaskEnv(TaskNewRelease)
-		
+		t.conf = self.conf
 		t.run()
 		n.flush()
 		self.assertEqual(len(n.events), 0)

--- a/tests/task_test.py
+++ b/tests/task_test.py
@@ -140,6 +140,8 @@ class TestTaskNewRelease(unittest.TestCase):
 	confRaw.read_dict(CONF)
 
 	conf = ConfSet(confRaw)
+	cf = '/etc/srvcheck.conf'
+	conf.addItem(ConfItem('configFile', cf, str))
 
 	def test_VersionCompare(self):
 		self.assertEqual(versionCompare('v1.0.0', 'v1.0.0'), 0)

--- a/tests/task_test.py
+++ b/tests/task_test.py
@@ -131,6 +131,7 @@ class TestTaskNewRelease(unittest.TestCase):
 
 	def test_noalert(self):
 		c, n, t, s = buildTaskEnv(TaskNewRelease)
+		
 		t.run()
 		n.flush()
 		self.assertEqual(len(n.events), 0)

--- a/tests/task_test.py
+++ b/tests/task_test.py
@@ -142,6 +142,7 @@ class TestTaskNewRelease(unittest.TestCase):
 	conf = ConfSet(confRaw)
 	cf = '/etc/srvcheck.conf'
 	conf.addItem(ConfItem('configFile', cf, str))
+	conf.addItem(ConfItem('chain.localVersion', 'v0.0.1', str))
 
 	def test_VersionCompare(self):
 		self.assertEqual(versionCompare('v1.0.0', 'v1.0.0'), 0)
@@ -159,7 +160,8 @@ class TestTaskNewRelease(unittest.TestCase):
 
 	def test_alert(self):
 		c, n, t, s = buildTaskEnv(TaskNewRelease)
-		c.latestVersion = 'v0.0.1'
+		t.conf = self.conf
+		c.latestVersion = 'v1.1.1'
 		t.run()
 		n.flush()
 		self.assertEqual(len(n.events), 1)


### PR DESCRIPTION
New release task has been modified. It keeps track of 3 states of node sw version:
- latest version (from api)
- current version (from sw installed)
- localVersion (latest current version known by the monitor)

This is needed for detecting when the current version is higher than the last local version. The local version is written on the conf file so that the task works even if the monitor is restarted after the update, as usually happens

close #98 