### PR TITLE
Bug Fixes and new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ The install script can be customized with these flags:
 ```
 install --help
      --active-set <active_set_number> number of the validators in the active set (tendermint chain) [default is the number of active validators]
+ -a  --validator-address <address> enable checks on block production
  -b  --block-time <time> expected block time [default is 60 seconds]
      --branch <name> name of the branch to use for the installation [default is main]
- -c  --collator <address> enable checks on block production and collation (parachain)
      --git <git_api> git api to query the latest realease version installed
      --rel <version> release version installed (required for tendermint chain if git_api is specified)
  -t  --telegram <chat_id> <token> telegram chat options (id and token) where the alerts will be sent [required]
@@ -120,8 +120,8 @@ blockWindow =
 ghRepository = 
 ; software version
 localVersion = 
-; parachain collator address
-collatorAddress = 
+; validator address
+validatorAddress = 
 ; mount point
 mountPoint = 
 

--- a/conf/srvcheck.conf
+++ b/conf/srvcheck.conf
@@ -27,8 +27,8 @@ blockWindow =
 ghRepository = 
 ; software version
 localVersion = 
-; parachain collator address
-collatorAddress = 
+; validator address
+validatorAddress = 
 ; mount point
 mountPoint = 
 

--- a/install.sh
+++ b/install.sh
@@ -14,9 +14,9 @@ install() {
 print_help () {
     echo "Usage: install [options...]
      --active-set <active_set_number> number of the validators in the active set (tendermint chain) [default is the number of active validators]
+ -a  --validator-address <address> enable checks on block production
  -b  --block-time <time> expected block time [default is 60 seconds]
      --branch <name> name of the branch to use for the installation [default is main]
- -c  --collator <address> enable checks on block production and collation (parachain)
      --git <git_api> git api to query the latest realease version installed
      --rel <version> release version installed (required for tendermint chain if git_api is specified)
  -t  --telegram <chat_id> <token> telegram chat options (id and token) where the alerts will be sent [required]
@@ -59,13 +59,13 @@ install_monitor () {
     then
         sed -i -e "s/^localVersion =.*/localVersion = $local_version/" $config_file
     fi
-    if [ ! -z "$collatorAddress" ]
+    if [ ! -z "$validatorAddress" ]
     then
-        sed -i -e "s/^collatorAddress =.*/collatorAddress = $collatorAddress/" $config_file
+        sed -i -e "s/^validatorAddress =.*/validatorAddress = $validatorAddress/" $config_file
     fi
     if [ ! -z "$mountPoint" ]
     then
-        sed -i -e "s/^mountPoint =.*/mountPoint = $mountPoint/" $config_file
+        sed -i -e "s,^mountPoint =.*,mountPoint = $mountPoint/" $config_file
     fi
     if [[ ! -z "$threshold_notsigned" && ! -z "$block_window" ]]
     then
@@ -103,6 +103,17 @@ case $1 in
         shift # past argument
         shift # past value
     ;;
+    -a|--validator-address)
+        if [[ -z $2 ]]
+        then
+            print_help
+            exit 1
+        else
+            validatorAddress="$2"
+        fi
+        shift # past argument
+        shift # past value
+    ;;
     -b|--block-time)
         if [[ -z $2 ]]
         then
@@ -110,17 +121,6 @@ case $1 in
             exit 1
         else
             block_time="$2"
-        fi
-        shift # past argument
-        shift # past value
-    ;;
-    -c|--collator)
-        if [[ -z $2 ]]
-        then
-            print_help
-            exit 1
-        else
-            collatorAddress="$2"
         fi
         shift # past argument
         shift # past value

--- a/install.sh
+++ b/install.sh
@@ -65,7 +65,7 @@ install_monitor () {
     fi
     if [ ! -z "$mountPoint" ]
     then
-        sed -i -e "s,^mountPoint =.*,mountPoint = $mountPoint/" $config_file
+        sed -i -e "s,^mountPoint =.*,mountPoint = $mountPoint,g" $config_file
     fi
     if [[ ! -z "$threshold_notsigned" && ! -z "$block_window" ]]
     then

--- a/srvcheck/chains/aptos.py
+++ b/srvcheck/chains/aptos.py
@@ -41,6 +41,7 @@ class TaskAptosValidatorProposalCheck(Task):
 		if self.prevEp is None:
 			self.prevEp = ep
 
+		print(f'#Debug TaskAptosValidatorProposalCheck: {self.ep}, {p_count}, {self.prevEpCount}')
 		if self.prevEp != ep:
 			self.prevEp = ep
 			if p_count == self.prevEpCount:
@@ -63,6 +64,7 @@ class TaskAptosCurrentConsensusStuck(Task):
 	def run(self):
 		cur_round = self.chain.getCurrentConsensus()
 
+		print(f'#Debug TaskAptosCurrentConsensusStuck: {self.prev}, {cur_round}')
 		if self.prev is None:
 			self.prev = cur_round
 			return False 
@@ -83,6 +85,7 @@ class TaskAptosConnectedToFullNodeCheck(Task):
 	def run(self):
 		conn = self.chain.getConnections()
 
+		print(f'#Debug TaskAptosConnectedToFullNodeCheck: {conn}')
 		if len(conn) > 0:
 			vfn_in = conn[1].split(" ")[-1]
 			if vfn_in == 0:
@@ -100,6 +103,8 @@ class TaskAptosConnectedToAptosNodeCheck(Task):
 
 	def run(self):
 		aptosPeerId = 'f326fd30'
+
+		print(f'#Debug TaskAptosConnectedToAptosNodeCheck: {self.chain.isConnectedToPeer(aptosPeerId)}')
 		if self.chain.isConnectedToPeer(aptosPeerId):
 			return self.notify(f'not connected to Aptos node {Emoji.Peers}')
 
@@ -117,6 +122,7 @@ class TaskAptosStateSyncCheck(Task):
 	def run(self):
 		sync = self.chain.getAptosStateSyncVersion()
 
+		print(f'#Debug TaskAptosStateSyncCheck: {sync}, {self.prev}')
 		if self.prev is None:
 			self.prev = sync
 		elif sync == self.prev:
@@ -127,7 +133,7 @@ class TaskAptosStateSyncCheck(Task):
 
 class TaskStakePoolRewardsCheck(Task):
 	def __init__(self, conf, notification, system, chain):
-		super().__init__('TaskStakePoolRewardsCheck', conf, notification, system, chain, checkEvery = minutes(5), notifyEvery=hours(1))
+		super().__init__('TaskStakePoolRewardsCheck', conf, notification, system, chain, checkEvery = minutes(30), notifyEvery=hours(1))
 		self.prev = None
 		self.prevEp = None
 
@@ -147,6 +153,7 @@ class TaskStakePoolRewardsCheck(Task):
 		if self.prevEp is None:
 			self.prevEp = ep
 
+		print(f'#Debug TaskStakePoolRewardsCheck: {ep}, {self.prev}, {stakedValue}')
 		if self.prevEp != ep:
 			self.prevEp = ep
 			if self.prev == stakedValue:

--- a/srvcheck/chains/aptos.py
+++ b/srvcheck/chains/aptos.py
@@ -92,7 +92,11 @@ class Aptos (Chain):
 
 	def getHeight(self):
 		out = requests.get(self.EP)
-		return json.loads(out.text)['ledger_version']
+		return json.loads(out.text)['block_height']
+
+	def getEpoch(self):
+		out = requests.get(self.EP)
+		return json.loads(out.text)['epoch']
 
 	def getBlockHash(self):
 		raise Exception('Abstract getBlockHash()')
@@ -104,13 +108,16 @@ class Aptos (Chain):
 	def getNetwork(self):
 		raise Exception('Abstract getNetwork()')
 
+	def getRole(self):
+		out = requests.get(self.EP)
+		return json.loads(out.text)['node_role']
+
 	def isStaking(self):
 		raise Exception('Abstract isStaking()')
 
 	def isValidator(self):
-		out = requests.get(self.EP_METRICS).text.split("\n")
-		role = [s for s in out if 'aptos_connections' in s and 'validator' in s]
-		return True if len(role) > 0 else False
+		role = self.getRole()
+		return True if role == "validator" else False
 
 	def isSynching(self):
 		out = requests.get(self.EP_METRICS).text.split("\n")

--- a/srvcheck/chains/aptos.py
+++ b/srvcheck/chains/aptos.py
@@ -48,11 +48,11 @@ class TaskAptosValidatorPerformanceCheck(Task):
 			activeStakeOut += f", {thisEpoch[7]} active stake {Emoji.ActStake if int(thisEpoch[7]) > int(lastEpoch[7]) else Emoji.LowBal}"
 			print(f'#Debug TaskAptosValidatorPerformanceCheck: {ep}, {lastEpoch[0]} new proposals {lastEpoch[3]} out of {lastEpoch[0]}, {thisEpoch[7]}')
 			if int(lastEpoch[0]) == 0:
-				return self.notify(f'is not proposing new consensus {Emoji.BlockMiss}\n\t{activeStakeOut}')
+				return self.notify(f'is not proposing new consensus {Emoji.BlockMiss}\n{activeStakeOut}')
 			elif int(lastEpoch[3])/int(lastEpoch[0]) < 0.25:
-				return self.notify(f'{int(lastEpoch[3])/int(lastEpoch[0]) * 100}% of proposals failed {Emoji.BlockMiss}\n\t{activeStakeOut}')
+				return self.notify(f'{int(lastEpoch[3])/int(lastEpoch[0]) * 100:.2f}% of proposals failed {Emoji.BlockMiss}\n{activeStakeOut}')
 			else:
-				return self.notify(f'proposed {lastEpoch[0]} new consensus, {int(lastEpoch[3])/int(lastEpoch[0]) * 100}% succeed {Emoji.BlockProd}\n\t{activeStakeOut}')
+				return self.notify(f'proposed {lastEpoch[0]} new consensus, {int(lastEpoch[3])/int(lastEpoch[0]) * 100:.2f}% succeed {Emoji.BlockProd}\n{activeStakeOut}')
 		return False
 	
 class TaskAptosCurrentConsensusStuck(Task):

--- a/srvcheck/chains/aptos.py
+++ b/srvcheck/chains/aptos.py
@@ -42,11 +42,11 @@ class TaskAptosValidatorPerformanceCheck(Task):
 		if self.prevEp != ep:
 			self.prevEp = ep
 			performance = self.chain.getValidatorPerformance()
-			lastEpoch = list(filter(lambda item: item, performance[1].replace('|', '').split(" ")))
-			epochBeforeLastEpoch = list(filter(lambda item: item, performance[0].replace('|', '').split(" ")))
-			activeStakeOut = "active stake increased" if int(lastEpoch[7]) > int(epochBeforeLastEpoch[7]) else 'active stake remained the same'
-			activeStakeOut += f", {lastEpoch[7]} active stake {Emoji.ActStake if int(lastEpoch[7]) > int(epochBeforeLastEpoch[7]) else Emoji.LowBal}"
-			print(f'#Debug TaskAptosValidatorPerformanceCheck: {ep}, {lastEpoch[0]} new proposals {int(lastEpoch[3])/int(lastEpoch[0]) * 100}%, {lastEpoch[7]}')
+			thisEpoch = list(filter(lambda item: item, performance[1].replace('|', '').split(" ")))
+			lastEpoch = list(filter(lambda item: item, performance[0].replace('|', '').split(" ")))
+			activeStakeOut = "active stake increased" if int(thisEpoch[7]) > int(lastEpoch[7]) else 'active stake remained the same'
+			activeStakeOut += f", {thisEpoch[7]} active stake {Emoji.ActStake if int(thisEpoch[7]) > int(lastEpoch[7]) else Emoji.LowBal}"
+			print(f'#Debug TaskAptosValidatorPerformanceCheck: {ep}, {lastEpoch[0]} new proposals {lastEpoch[3]} out of {lastEpoch[0]}, {thisEpoch[7]}')
 			if int(lastEpoch[0]) == 0:
 				return self.notify(f'is not proposing new consensus {Emoji.BlockMiss}\n\t{activeStakeOut}')
 			elif int(lastEpoch[3])/int(lastEpoch[0]) < 0.25:

--- a/srvcheck/chains/aptos.py
+++ b/srvcheck/chains/aptos.py
@@ -221,7 +221,7 @@ class Aptos (Chain):
 
 	def getConnections(self):
 		out = requests.get(self.EP_METRICS).text.split("\n")
-		connections = [s for s in out if 'aptos_connections' in s]
+		connections = [s for s in out if 'aptos_connections' in s and '#' not in s]
 		return connections
 
 	def isConnectedToPeer(self, peerId):

--- a/srvcheck/chains/aptos.py
+++ b/srvcheck/chains/aptos.py
@@ -42,14 +42,14 @@ class TaskAptosValidatorPerformanceCheck(Task):
 		if self.prevEp != ep:
 			self.prevEp = ep
 			performance = self.chain.getValidatorPerformance()
-			lastEpoch = list(filter(lambda item: item, performance[:1].replace('|', '').split(" ")))
+			lastEpoch = list(filter(lambda item: item, performance[1].replace('|', '').split(" ")))
 			epochBeforeLastEpoch = list(filter(lambda item: item, performance[0].replace('|', '').split(" ")))
 			activeStakeOut = "active stake increased" if int(lastEpoch[7]) > int(epochBeforeLastEpoch[7]) else 'active stake remained the same'
-			activeStakeOut += f"{lastEpoch[7]} active stake {Emoji.ActStake if int(lastEpoch[7]) > int(epochBeforeLastEpoch[7]) else Emoji.LowBal}"
+			activeStakeOut += f", {lastEpoch[7]} active stake {Emoji.ActStake if int(lastEpoch[7]) > int(epochBeforeLastEpoch[7]) else Emoji.LowBal}"
 			print(f'#Debug TaskAptosValidatorPerformanceCheck: {ep}, {lastEpoch[0]} new proposals {int(lastEpoch[3])/int(lastEpoch[0]) * 100}%, {lastEpoch[7]}')
 			if int(lastEpoch[0]) == 0:
 				return self.notify(f'is not proposing new consensus {Emoji.BlockMiss}\n\t{activeStakeOut}')
-			elif int(lastEpoch[3])/int(lastEpoch[0]) > 0.25:
+			elif int(lastEpoch[3])/int(lastEpoch[0]) < 0.25:
 				return self.notify(f'{int(lastEpoch[3])/int(lastEpoch[0]) * 100}% of proposals failed {Emoji.BlockMiss}\n\t{activeStakeOut}')
 			else:
 				return self.notify(f'proposed {lastEpoch[0]} new consensus, {int(lastEpoch[3])/int(lastEpoch[0]) * 100}% succeed {Emoji.BlockProd}\n\t{activeStakeOut}')
@@ -227,4 +227,4 @@ class Aptos (Chain):
 		if validatorAddress[:2] == '0x':
 			validatorAddress = validatorAddress[2:]
 		performance = Bash(f"aptos node analyze-validator-performance --analyze-mode=detailed-epoch-table --url=https://ait3.aptosdev.com/ | grep {validatorAddress}").value().split("\n")
-		return performance[:-1]
+		return performance

--- a/srvcheck/chains/aptos.py
+++ b/srvcheck/chains/aptos.py
@@ -211,7 +211,7 @@ class Aptos (Chain):
 
 	def getAptosStateSyncVersion(self):
 		out = requests.get(self.EP_METRICS).text.split("\n")
-		state_sync = [s for s in out if 'aptos_state_sync_version' and 'synced' in s]
+		state_sync = [s for s in out if 'aptos_state_sync_version' in s and 'synced' in s]
 		return state_sync
 
 	def getNetwork(self):

--- a/srvcheck/chains/aptos.py
+++ b/srvcheck/chains/aptos.py
@@ -1,6 +1,6 @@
-import requests
-import re
 import json
+import re
+import requests
 from ..notification import Emoji
 from .chain import Chain
 from ..tasks import Task,  hours, minutes

--- a/srvcheck/chains/aptos.py
+++ b/srvcheck/chains/aptos.py
@@ -105,7 +105,7 @@ class TaskAptosConnectedToAptosNodeCheck(Task):
 		aptosPeerId = 'f326fd30'
 
 		print(f'#Debug TaskAptosConnectedToAptosNodeCheck: {self.chain.isConnectedToPeer(aptosPeerId)}')
-		if self.chain.isConnectedToPeer(aptosPeerId):
+		if self.chain.isConnectedToPeer(aptosPeerId) is False:
 			return self.notify(f'not connected to Aptos node {Emoji.Peers}')
 
 		return False

--- a/srvcheck/chains/aptos.py
+++ b/srvcheck/chains/aptos.py
@@ -201,11 +201,13 @@ class Aptos (Chain):
 
 	def getPeerCount(self):
 		conn = self.getConnections()
-		if len(conn) > 1:
-			in_peer = int(conn[0].split(" ")[-1])
-			out_peer = int(conn[2].split(" ")[-1])
-			return in_peer + out_peer
-		return 0
+		if self.isValidator():
+			if len(conn) > 1:
+				in_peer = int(conn[0].split(" ")[-1])
+				out_peer = int(conn[2].split(" ")[-1])
+				return in_peer + out_peer
+			return 0
+		raise Exception('Abstract getPeerCount()')
 
 	def getAptosStateSyncVersion(self):
 		out = requests.get(self.EP_METRICS).text.split("\n")

--- a/srvcheck/chains/aptos.py
+++ b/srvcheck/chains/aptos.py
@@ -68,7 +68,7 @@ class Aptos (Chain):
 	TYPE = "aptos"
 	NAME = "aptos"
 	BLOCKTIME = 15
-	EP = 'http://localhost:8080'
+	EP = 'http://localhost:8080/v1'
 	EP_METRICS = 'http://localhost:9101/metrics'
 	CUSTOM_TASKS = [TaskAptosHealthError, TaskAptosValidatorProposalCheck, TaskAptosCurrentConsensusStuck]
 
@@ -86,7 +86,7 @@ class Aptos (Chain):
 		raise Exception('Abstract getVersion()')
 
 	def getHealth(self):
-		out = requests.get(f"{self.EP}/v1/-/healthy")
+		out = requests.get(f"{self.EP}/-/healthy")
 		health = json.loads(out.text)['message']
 		return True if health == 'aptos-node:ok' else False
 

--- a/srvcheck/chains/aptos.py
+++ b/srvcheck/chains/aptos.py
@@ -68,7 +68,7 @@ class Aptos (Chain):
 	TYPE = "aptos"
 	NAME = "aptos"
 	BLOCKTIME = 15
-	EP = 'http://localhost:8080/'
+	EP = 'http://localhost:8080'
 	EP_METRICS = 'http://localhost:9101/metrics'
 	CUSTOM_TASKS = [TaskAptosHealthError, TaskAptosValidatorProposalCheck, TaskAptosCurrentConsensusStuck]
 
@@ -87,7 +87,8 @@ class Aptos (Chain):
 
 	def getHealth(self):
 		out = requests.get(f"{self.EP}/v1/-/healthy")
-		return True if out.text == 'aptos-node:ok' else False
+		health = json.loads(out.text)['message']
+		return True if health == 'aptos-node:ok' else False
 
 	def getHeight(self):
 		out = requests.get(self.EP)

--- a/srvcheck/chains/aptos.py
+++ b/srvcheck/chains/aptos.py
@@ -41,7 +41,7 @@ class TaskAptosValidatorProposalCheck(Task):
 		if self.prevEp is None:
 			self.prevEp = ep
 
-		print(f'#Debug TaskAptosValidatorProposalCheck: {self.ep}, {p_count}, {self.prevEpCount}')
+		print(f'#Debug TaskAptosValidatorProposalCheck: {ep}, {p_count}, {self.prevEpCount}')
 		if self.prevEp != ep:
 			self.prevEp = ep
 			if p_count == self.prevEpCount:
@@ -88,7 +88,7 @@ class TaskAptosConnectedToFullNodeCheck(Task):
 		print(f'#Debug TaskAptosConnectedToFullNodeCheck: {conn}')
 		if len(conn) > 0:
 			vfn_in = conn[1].split(" ")[-1]
-			if vfn_in == 0:
+			if vfn_in == "0":
 				return self.notify(f'validator not connected to full node {Emoji.NoLeader}')
 
 		return False
@@ -120,7 +120,7 @@ class TaskAptosStateSyncCheck(Task):
 		return True
 
 	def run(self):
-		sync = self.chain.getAptosStateSyncVersion()
+		sync = int(self.chain.getAptosStateSyncVersion()[0].split(" ")[-1])
 
 		print(f'#Debug TaskAptosStateSyncCheck: {sync}, {self.prev}')
 		if self.prev is None:
@@ -202,8 +202,8 @@ class Aptos (Chain):
 	def getPeerCount(self):
 		conn = self.getConnections()
 		if len(conn) > 1:
-			in_peer = conn[0].split(" ")[-1]
-			out_peer = conn[2].split(" ")[-1]
+			in_peer = int(conn[0].split(" ")[-1])
+			out_peer = int(conn[2].split(" ")[-1])
 			return in_peer + out_peer
 		return 0
 

--- a/srvcheck/chains/substrate.py
+++ b/srvcheck/chains/substrate.py
@@ -118,14 +118,14 @@ class TaskBlockProductionReport(Task):
 		if self.prev != era:
 			self.prev = era
 			report = f'validated in {self.prevValidatedSessions} active sessions out of {self.prevTotalSessions} in the last era {Emoji.Leader if self.prevValidatedSessions > 0 else Emoji.NoLeader}\n'
+			self.prevTotalSessions = 0
 			if self.totalBlockChecked > 0:
 				report += f'produced {self.oc} blocks out of {self.totalBlockChecked} ({self.oc / self.totalBlockChecked * 100:.2f} %)'
 				self.totalBlockChecked = 0
-			report = f'{report} {Emoji.BlockProd}'
-			self.oc = 0
-			self.prevTotalSessions = 0
-			self.prevValidatedSessions = 0
-			return self.notify(report)
+				report = f'{report} {Emoji.BlockProd}'
+				self.oc = 0
+				self.prevValidatedSessions = 0
+				return self.notify(report)
 
 		if self.prevSession != session:
 			if self.chain.isValidator():

--- a/srvcheck/chains/substrate.py
+++ b/srvcheck/chains/substrate.py
@@ -117,9 +117,9 @@ class TaskBlockProductionReport(Task):
 
 		if self.prev != era:
 			self.prev = era
-			report = f'{self.prevValidatedSessions} out of {self.prevTotalSessions} last era'
+			report = f'validated in {self.prevValidatedSessions} active sessions out of {self.prevTotalSessions} in the last era {Emoji.Leader if self.prevValidatedSessions > 0 else Emoji.NoLeader}\n'
 			if self.totalBlockChecked > 0:
-				report += f', and produced {self.oc} blocks out of {self.totalBlockChecked} ({self.oc / self.totalBlockChecked * 100:.2f} %)'
+				report += f'produced {self.oc} blocks out of {self.totalBlockChecked} ({self.oc / self.totalBlockChecked * 100:.2f} %)'
 				self.totalBlockChecked = 0
 			report = f'{report} {Emoji.BlockProd}'
 			self.oc = 0

--- a/srvcheck/chains/substrate.py
+++ b/srvcheck/chains/substrate.py
@@ -199,8 +199,9 @@ class Substrate (Chain):
 		return (len(cc['primary']) + len(cc['secondary']) + len(cc['secondary_vrf'])) > 0
 
 	def isSynching(self):
-		c = self.rpcCall('system_syncState')
-		return abs(c['currentBlock'] - c['highestBlock']) > 32
+		c = self.rpcCall('system_syncState')['currentBlock']
+		h = self.getHeight()
+		return abs(c - h) > 32
 
 	def getRelayHeight(self):
 		si = self.getSubstrateInterface()

--- a/srvcheck/chains/substrate.py
+++ b/srvcheck/chains/substrate.py
@@ -119,7 +119,7 @@ class TaskBlockProductionReport(Task):
 			self.prev = era
 			report = f'{self.prevValidatedSessions} out of {self.prevTotalSessions} last era'
 			if self.totalBlockChecked > 0:
-				report = f', and produced {report} blocks out of {self.totalBlockChecked} ({self.oc / self.totalBlockChecked * 100:.2f} %)'
+				report += f', and produced {self.oc} blocks out of {self.totalBlockChecked} ({self.oc / self.totalBlockChecked * 100:.2f} %)'
 				self.totalBlockChecked = 0
 			report = f'{report} {Emoji.BlockProd}'
 			self.oc = 0

--- a/srvcheck/chains/substrate.py
+++ b/srvcheck/chains/substrate.py
@@ -6,7 +6,7 @@ from ..tasks import Task
 from ..notification import Emoji
 from ..utils import ConfItem, ConfSet, Bash
 
-ConfSet.addItem(ConfItem('chain.collatorAddress', description='Collator address'))
+ConfSet.addItem(ConfItem('chain.validatorAddress', description='Validator address'))
 
 class TaskSubstrateNewReferenda(Task):
 	def __init__(self, conf, notification, system, chain, checkEvery=hours(1), notifyEvery=60*10*60):
@@ -109,7 +109,7 @@ class TaskBlockProductionReport(Task):
 			blocksToCheck = [b for b in self.chain.getExpectedBlocks() if b <= currentBlock and (self.lastBlockChecked is None or b > self.lastBlockChecked)]
 			for b in blocksToCheck:
 				a = self.chain.getBlockAuthor(b)
-				collator = self.conf.getOrDefault('chain.collatorAddress')
+				collator = self.conf.getOrDefault('chain.validatorAddress')
 				if a.lower() == collator.lower():
 					self.oc += 1
 				self.lastBlockChecked = b
@@ -175,7 +175,7 @@ class TaskBlockProductionReportParachain(Task):
 				blocksToCheck = [b for b in self.chain.getExpectedBlocks() if b <= currentBlock and (self.lastBlockChecked is None or b > self.lastBlockChecked) and b >= startingRoundBlock]
 				for b in blocksToCheck:
 					a = self.chain.getBlockAuthor(b)
-					collator = orb if orb != '0x0' and orb is not None else self.conf.getOrDefault('chain.collatorAddress')
+					collator = orb if orb != '0x0' and orb is not None else self.conf.getOrDefault('chain.validatorAddress')
 					if a.lower() == collator.lower():
 						self.oc += 1
 					self.lastBlockChecked = b
@@ -255,7 +255,7 @@ class Substrate (Chain):
 		cc = c[c.keys()[0]]
 		return (len(cc['primary']) + len(cc['secondary']) + len(cc['secondary_vrf'])) > 0'''
 		si = self.getSubstrateInterface()
-		collator = self.conf.getOrDefault('chain.collatorAddress')
+		collator = self.conf.getOrDefault('chain.validatorAddress')
 		era = self.getEra()
 		result = si.query(module='Staking', storage_function='ErasStakers', params=[era, collator])
 		if result.value["total"] > 0:
@@ -304,7 +304,7 @@ class Substrate (Chain):
 			return -1
 
 	def isValidator(self):
-		collator = self.conf.getOrDefault('chain.collatorAddress')
+		collator = self.conf.getOrDefault('chain.validatorAddress')
 		if collator:
 			try:
 				# Check validator on Shiden/Shibuya, Mangata
@@ -318,7 +318,7 @@ class Substrate (Chain):
 		return False
 
 	def isCollating(self):
-		collator = self.conf.getOrDefault('chain.collatorAddress')
+		collator = self.conf.getOrDefault('chain.validatorAddress')
 		if collator:
 			si = self.getSubstrateInterface()
 			try:
@@ -343,7 +343,7 @@ class Substrate (Chain):
 		return False
 
 	def latestBlockProduced(self):
-		collator = self.conf.getOrDefault('chain.collatorAddress')
+		collator = self.conf.getOrDefault('chain.validatorAddress')
 		if collator:
 			try:
 				# Check last block produced on Shiden/Shibuya
@@ -370,7 +370,7 @@ class Substrate (Chain):
 			return self.checkAuthoredBlock(block)
 
 	def moonbeamAssignedOrbiter(self):
-		collator = self.conf.getOrDefault('chain.collatorAddress')
+		collator = self.conf.getOrDefault('chain.validatorAddress')
 		if collator:
 			try:
 				si = self.getSubstrateInterface()
@@ -389,5 +389,5 @@ class Substrate (Chain):
 		seals = self.getSeals(block)
 		for b in seals:
 			if b == bh:
-				return self.conf.getOrDefault('chain.collatorAddress')
+				return self.conf.getOrDefault('chain.validatorAddress')
 		return "0x0"

--- a/srvcheck/chains/tendermint.py
+++ b/srvcheck/chains/tendermint.py
@@ -68,16 +68,16 @@ class TaskTendermintNewProposal(Task):
 			self.prev = nProposal
 			if len(self.prev) > 0:
 				return self.notify(f'got latest proposal: {self.getProposalTitle(nProposal[0])} {Emoji.Proposal}')
-		elif "id" in self.prev and self.prev[0]["id"] < nProposal[0]["id"]:
-			c = nProposal[0]["id"] - self.prev[0]["id"]
-			while(c == 0):
+		elif "id" in self.prev[0] and int(self.prev[0]["id"]) < int(nProposal[0]["id"]):
+			c = int(nProposal[0]["id"]) - int(self.prev[0]["id"])
+			while(c >= 0):
 				self.notify(f'got new proposal: {self.getProposalTitle(nProposal[c])} {Emoji.Proposal}')
 				c -= 1
 			self.prev = nProposal
 			return True
-		elif "proposal_id" in self.prev and self.prev[0]["proposal_id"] < nProposal[0]["proposal_id"]:
-			c = nProposal[0]["proposal_id"] - self.prev[0]["proposal_id"]
-			while(c == 0):
+		elif "proposal_id" in self.prev[0] and int(self.prev[0]["proposal_id"]) < int(nProposal[0]["proposal_id"]):
+			c = int(nProposal[0]["proposal_id"]) - int(self.prev[0]["proposal_id"])
+			while(c >= 0):
 				self.notify(f'got new proposal: {self.getProposalTitle(nProposal[c])} {Emoji.Proposal}')
 				c -= 1
 			self.prev = nProposal

--- a/srvcheck/chains/tendermint.py
+++ b/srvcheck/chains/tendermint.py
@@ -74,7 +74,6 @@ class TaskTendermintNewProposal(Task):
 				self.notify(f'got new proposal: {self.getProposalTitle(nProposal[c])} {Emoji.Proposal}')
 				c -= 1
 			self.prev = nProposal
-			self.notification.flush()
 			return True
 		elif "proposal_id" in self.prev and self.prev[0]["proposal_id"] < nProposal[0]["proposal_id"]:
 			c = nProposal[0]["proposal_id"] - self.prev[0]["proposal_id"]
@@ -82,7 +81,6 @@ class TaskTendermintNewProposal(Task):
 				self.notify(f'got new proposal: {self.getProposalTitle(nProposal[c])} {Emoji.Proposal}')
 				c -= 1
 			self.prev = nProposal
-			self.notification.flush()
 			return True
 		return False
 

--- a/srvcheck/chains/tendermint.py
+++ b/srvcheck/chains/tendermint.py
@@ -71,15 +71,15 @@ class TaskTendermintNewProposal(Task):
 		elif "id" in self.prev[0] and int(self.prev[0]["id"]) < int(nProposal[0]["id"]):
 			c = int(nProposal[0]["id"]) - int(self.prev[0]["id"])
 			while(c >= 0):
-				self.notify(f'got new proposal: {self.getProposalTitle(nProposal[c])} {Emoji.Proposal}')
 				c -= 1
+				self.notify(f'got new proposal: {self.getProposalTitle(nProposal[c])} {Emoji.Proposal}')
 			self.prev = nProposal
 			return True
 		elif "proposal_id" in self.prev[0] and int(self.prev[0]["proposal_id"]) < int(nProposal[0]["proposal_id"]):
 			c = int(nProposal[0]["proposal_id"]) - int(self.prev[0]["proposal_id"])
 			while(c >= 0):
-				self.notify(f'got new proposal: {self.getProposalTitle(nProposal[c])} {Emoji.Proposal}')
 				c -= 1
+				self.notify(f'got new proposal: {self.getProposalTitle(nProposal[c])} {Emoji.Proposal}')
 			self.prev = nProposal
 			return True
 		return False

--- a/srvcheck/chains/tendermint.py
+++ b/srvcheck/chains/tendermint.py
@@ -62,6 +62,18 @@ class TaskTendermintNewProposal(Task):
 		elif "proposal_id" in proposal:
 			return proposal["content"]["title"]
 
+	def notifyAboutLatestProposals(self, proposals, key):
+		nProposalUnread = [prop for prop in proposals if int(self.prev[0][key]) < int(prop[key])]
+		c = len(nProposalUnread)
+		if c > 0:
+			out = f'got {c} new proposal: '
+			for i, p in enumerate(nProposalUnread):
+				if i > 0 and i < len(nProposalUnread):
+					out += '\n'
+				out += f'{self.getProposalTitle(p)}{" " + Emoji.Proposal if i == len(nProposalUnread) - 1 else ""}'
+			self.prev = proposals
+			return self.notify(out)
+
 	def run(self):
 		nProposal = self.chain.getLatestProposals()
 		if not self.prev:
@@ -69,25 +81,9 @@ class TaskTendermintNewProposal(Task):
 			if len(self.prev) > 0:
 				return self.notify(f'got latest proposal: {self.getProposalTitle(nProposal[0])} {Emoji.Proposal}')
 		elif "id" in self.prev[0]:
-			nProposalUnread = [prop for prop in nProposal if int(self.prev[0]["id"]) < int(prop["id"])]
-			c = len(nProposalUnread)
-			out = f'got {c} new proposal: '
-			for i, p in enumerate(nProposalUnread):
-				if i > 0 and i < len(nProposalUnread):
-					out += '\n'
-				out += f'{self.getProposalTitle(p)}{" " + Emoji.Proposal if i == len(nProposalUnread) - 1 else ""}'
-			self.prev = nProposal
-			return self.notify(out)
+			self.notifyAboutLatestProposals(nProposal, "id")
 		elif "proposal_id" in self.prev[0] and int(self.prev[0]["proposal_id"]) < int(nProposal[0]["proposal_id"]):
-			nProposalUnread = [prop for prop in nProposal if int(self.prev[0]["proposal_id"]) < int(prop["proposal_id"])]
-			c = len(nProposalUnread)
-			out = f'got {c} new proposal: '
-			for i, p in enumerate(nProposalUnread):
-				if i > 0 and i < len(nProposalUnread):
-					out += '\n'
-				out += f'{self.getProposalTitle(p)}{" " + Emoji.Proposal if i == len(nProposalUnread) - 1 else ""}'
-			self.prev = nProposal
-			return self.notify(out)
+			self.notifyAboutLatestProposals(nProposal, "proposal_id")
 		return False
 
 class TaskTendermintPositionChanged(Task):

--- a/srvcheck/chains/tendermint.py
+++ b/srvcheck/chains/tendermint.py
@@ -68,20 +68,26 @@ class TaskTendermintNewProposal(Task):
 			self.prev = nProposal
 			if len(self.prev) > 0:
 				return self.notify(f'got latest proposal: {self.getProposalTitle(nProposal[0])} {Emoji.Proposal}')
-		elif "id" in self.prev[0] and int(self.prev[0]["id"]) < int(nProposal[0]["id"]):
-			c = int(nProposal[0]["id"]) - int(self.prev[0]["id"])
-			while(c >= 0):
-				c -= 1
-				self.notify(f'got new proposal: {self.getProposalTitle(nProposal[c])} {Emoji.Proposal}')
+		elif "id" in self.prev[0]:
+			nProposalUnread = [prop for prop in nProposal if int(self.prev[0]["id"]) < int(prop["id"])]
+			c = len(nProposalUnread)
+			out = f'got {c} new proposal: '
+			for i, p in enumerate(nProposalUnread):
+				if i > 0 and i < len(nProposalUnread):
+					out += '\n'
+				out += f'{self.getProposalTitle(p)}{" " + Emoji.Proposal if i == len(nProposalUnread) - 1 else ""}'
 			self.prev = nProposal
-			return True
+			return self.notify(out)
 		elif "proposal_id" in self.prev[0] and int(self.prev[0]["proposal_id"]) < int(nProposal[0]["proposal_id"]):
-			c = int(nProposal[0]["proposal_id"]) - int(self.prev[0]["proposal_id"])
-			while(c >= 0):
-				c -= 1
-				self.notify(f'got new proposal: {self.getProposalTitle(nProposal[c])} {Emoji.Proposal}')
+			nProposalUnread = [prop for prop in nProposal if int(self.prev[0]["proposal_id"]) < int(prop["proposal_id"])]
+			c = len(nProposalUnread)
+			out = f'got {c} new proposal: '
+			for i, p in enumerate(nProposalUnread):
+				if i > 0 and i < len(nProposalUnread):
+					out += '\n'
+				out += f'{self.getProposalTitle(p)}{" " + Emoji.Proposal if i == len(nProposalUnread) - 1 else ""}'
 			self.prev = nProposal
-			return True
+			return self.notify(out)
 		return False
 
 class TaskTendermintPositionChanged(Task):

--- a/srvcheck/tasks/taskchainstuck.py
+++ b/srvcheck/tasks/taskchainstuck.py
@@ -32,13 +32,6 @@ class TaskChainStuck(Task):
 	def run(self):
 		bh = self.method()
 
-		if self.oc > 0:
-			elapsed = elapsedToString(self.since)
-			prevOc = self.oc
-			self.oc = 0
-			self.prev = bh
-			return self.notify(f'chain come back in sync after {elapsed} ({prevOc}) {Emoji.SyncOk}')
-
 		if self.prev is None:
 			self.prev = bh
 			self.since = time.time()
@@ -48,6 +41,13 @@ class TaskChainStuck(Task):
 			self.oc += 1
 			elapsed = elapsedToString(self.since)
 			return self.notify(f'chain is stuck at block {bh} since {elapsed} ({self.oc}) {Emoji.Stuck}')
+
+		if self.oc > 0:
+			elapsed = elapsedToString(self.since)
+			prevOc = self.oc
+			self.oc = 0
+			self.prev = bh
+			return self.notify(f'chain come back in sync after {elapsed} ({prevOc}) {Emoji.SyncOk}')
 
 		self.prev = bh
 		self.since = time.time()

--- a/srvcheck/tasks/taskchainstuck.py
+++ b/srvcheck/tasks/taskchainstuck.py
@@ -14,7 +14,7 @@ def elapsedToString(since):
 
 class TaskChainStuck(Task):
 	def __init__(self, conf, notification, system, chain):
-		super().__init__('TaskChainStuck', conf, notification, system, chain, chain.BLOCKTIME * 2, minutes(5))
+		super().__init__('TaskChainStuck', conf, notification, system, chain, chain.BLOCKTIME * 2, chain.BLOCKTIME * 2)
 		self.prev = None
 		self.since = None
 		self.oc = 0
@@ -34,8 +34,10 @@ class TaskChainStuck(Task):
 
 		if self.oc > 0:
 			elapsed = elapsedToString(self.since)
-			self.notify(f'chain come back in sync after {elapsed} ({self.oc}) {Emoji.SyncOk}')
-			self.notification.flush()
+			prevOc = self.oc
+			self.oc = 0
+			self.prev = bh
+			return self.notify(f'chain come back in sync after {elapsed} ({prevOc}) {Emoji.SyncOk}')
 
 		if self.prev is None:
 			self.prev = bh

--- a/tests/mocks/mockchain.py
+++ b/tests/mocks/mockchain.py
@@ -56,8 +56,13 @@ class MockChain(Chain):
         else:
             raise Exception('Mockchain is not healthy')
 
-
 class MockChainTendermint(MockChain):
+    latestProposals = [{"id":"1","messages":[{"@type":"/cosmos.gov.v1.MsgExecLegacyContent","content":{"@type":"/cosmos.params.v1beta1.ParameterChangeProposal","title":"Increase Signed Blocks Window Parameter to 2880","description":"Mamaki Testnet initially started with very strict slashing conditions. This proposal changes the signed_blocks_window to about 24 hours.","changes":[{"subspace":"slashing","key":"SignedBlocksWindow","value":"\"2880\""}]},"authority":"celestia10d07y265gmmuvt4z0w9aw880jnsr700jtgz4v7"}],"status":"PROPOSAL_STATUS_VOTING_PERIOD","final_tally_result":{"yes_count":"0","abstain_count":"0","no_count":"0","no_with_veto_count":"0"},"submit_time":"2022-06-10T13:43:02.649255900Z","deposit_end_time":"2022-06-12T13:43:02.649255900Z","total_deposit":[{"denom":"utia","amount":"100100000"}],"voting_start_time":"2022-06-10T13:49:16.069169911Z","voting_end_time":"2022-06-12T13:49:16.069169911Z","metadata":""}]
+
+    def getLatestProposals(self):
+        return self.latestProposals
+
+class MockChainTendermint1(MockChain):
     latestProposals = [{"proposal_id":"2","content":{"@type":"/ibc.core.client.v1.ClientUpdateProposal","title":"upgrade client","description":"upgrade light client","subject_client_id":"07-tendermint-0","substitute_client_id":"07-tendermint-2"},
 		"status":"PROPOSAL_STATUS_VOTING_PERIOD","final_tally_result":{"yes":"103022468704","abstain":"56100000","no":"115992000","no_with_veto":"90000000"},"submit_time":"2022-04-25T06:22:25.564973762Z","deposit_end_time":"2022-05-09T06:22:25.564973762Z","total_deposit":[{"denom":"ufis","amount":"1000000000"}],
 		"voting_start_time":"2022-04-25T06:23:01.163682205Z","voting_end_time":"2022-04-26T06:23:01.163682205Z"}, {"proposal_id":"1","content":{"@type":"/ibc.core.client.v1.ClientUpdateProposal","title":"upgrade client","description":"upgrade light client","subject_client_id":"07-tendermint-0","substitute_client_id":"07-tendermint-2"},
@@ -67,11 +72,21 @@ class MockChainTendermint(MockChain):
     def getLatestProposals(self):
         return self.latestProposals
 
-class MockChainTendermint1(MockChain):
-    latestProposals = [{"iproposal_idd":"2","content":{"@type":"/ibc.core.client.v1.ClientUpdateProposal","title":"upgrade client","description":"upgrade light client","subject_client_id":"07-tendermint-0","substitute_client_id":"07-tendermint-2"},
-		"status":"PROPOSAL_STATUS_FAILED","final_tally_result":{"yes":"103022468704","abstain":"56100000","no":"115992000","no_with_veto":"90000000"},"submit_time":"2022-04-25T06:22:25.564973762Z","deposit_end_time":"2022-05-09T06:22:25.564973762Z","total_deposit":[{"denom":"ufis","amount":"1000000000"}],
-		"voting_start_time":"2022-04-25T06:23:01.163682205Z","voting_end_time":"2022-04-26T06:23:01.163682205Z"}, {"proposal_id":"1","content":{"@type":"/ibc.core.client.v1.ClientUpdateProposal","title":"upgrade client","description":"upgrade light client","subject_client_id":"07-tendermint-0","substitute_client_id":"07-tendermint-2"},
-		"status":"PROPOSAL_STATUS_FAILED","final_tally_result":{"yes":"103022468704","abstain":"56100000","no":"115992000","no_with_veto":"90000000"},"submit_time":"2022-04-25T06:22:25.564973762Z","deposit_end_time":"2022-05-09T06:22:25.564973762Z","total_deposit":[{"denom":"ufis","amount":"1000000000"}],
+class MockChainTendermint2(MockChain):
+    latestProposals = [{"proposal_id":"1","content":{"@type":"/ibc.core.client.v1.ClientUpdateProposal","title":"upgrade client","description":"upgrade light client","subject_client_id":"07-tendermint-0","substitute_client_id":"07-tendermint-2"},
+		"status":"PROPOSAL_STATUS_VOTING_PERIOD","final_tally_result":{"yes":"103022468704","abstain":"56100000","no":"115992000","no_with_veto":"90000000"},"submit_time":"2022-04-25T06:22:25.564973762Z","deposit_end_time":"2022-05-09T06:22:25.564973762Z","total_deposit":[{"denom":"ufis","amount":"1000000000"}],
+		"voting_start_time":"2022-04-25T06:23:01.163682205Z","voting_end_time":"2022-04-26T06:23:01.163682205Z"}]
+
+    def getLatestProposals(self):
+        return self.latestProposals
+
+class MockChainTendermint3(MockChain):
+    latestProposals = [{"proposal_id":"3","content":{"@type":"/ibc.core.client.v1.ClientUpdateProposal","title":"Increase Signed Blocks Window Parameter to 2880","description":"upgrade light client","subject_client_id":"07-tendermint-0","substitute_client_id":"07-tendermint-2"},
+		"status":"PROPOSAL_STATUS_VOTING_PERIOD","final_tally_result":{"yes":"103022468704","abstain":"56100000","no":"115992000","no_with_veto":"90000000"},"submit_time":"2022-04-25T06:22:25.564973762Z","deposit_end_time":"2022-05-09T06:22:25.564973762Z","total_deposit":[{"denom":"ufis","amount":"1000000000"}],
+		"voting_start_time":"2022-04-25T06:23:01.163682205Z","voting_end_time":"2022-04-26T06:23:01.163682205Z"},{"proposal_id":"2","content":{"@type":"/ibc.core.client.v1.ClientUpdateProposal","title":"upgrade client","description":"upgrade light client","subject_client_id":"07-tendermint-0","substitute_client_id":"07-tendermint-2"},
+		"status":"PROPOSAL_STATUS_VOTING_PERIOD","final_tally_result":{"yes":"103022468704","abstain":"56100000","no":"115992000","no_with_veto":"90000000"},"submit_time":"2022-04-25T06:22:25.564973762Z","deposit_end_time":"2022-05-09T06:22:25.564973762Z","total_deposit":[{"denom":"ufis","amount":"1000000000"}],
+		"voting_start_time":"2022-04-25T06:23:01.163682205Z","voting_end_time":"2022-04-26T06:23:01.163682205Z"},{"proposal_id":"1","content":{"@type":"/ibc.core.client.v1.ClientUpdateProposal","title":"upgrade client","description":"upgrade light client","subject_client_id":"07-tendermint-0","substitute_client_id":"07-tendermint-2"},
+		"status":"PROPOSAL_STATUS_VOTING_PERIOD","final_tally_result":{"yes":"103022468704","abstain":"56100000","no":"115992000","no_with_veto":"90000000"},"submit_time":"2022-04-25T06:22:25.564973762Z","deposit_end_time":"2022-05-09T06:22:25.564973762Z","total_deposit":[{"denom":"ufis","amount":"1000000000"}],
 		"voting_start_time":"2022-04-25T06:23:01.163682205Z","voting_end_time":"2022-04-26T06:23:01.163682205Z"}]
 
     def getLatestProposals(self):

--- a/tests/mocks/mockchain.py
+++ b/tests/mocks/mockchain.py
@@ -60,7 +60,7 @@ class MockChainTendermint(MockChain):
     latestProposals = [{"id":"1","messages":[{"@type":"/cosmos.gov.v1.MsgExecLegacyContent","content":{"@type":"/cosmos.params.v1beta1.ParameterChangeProposal","title":"Increase Signed Blocks Window Parameter to 2880","description":"Mamaki Testnet initially started with very strict slashing conditions. This proposal changes the signed_blocks_window to about 24 hours.","changes":[{"subspace":"slashing","key":"SignedBlocksWindow","value":"\"2880\""}]},"authority":"celestia10d07y265gmmuvt4z0w9aw880jnsr700jtgz4v7"}],"status":"PROPOSAL_STATUS_VOTING_PERIOD","final_tally_result":{"yes_count":"0","abstain_count":"0","no_count":"0","no_with_veto_count":"0"},"submit_time":"2022-06-10T13:43:02.649255900Z","deposit_end_time":"2022-06-12T13:43:02.649255900Z","total_deposit":[{"denom":"utia","amount":"100100000"}],"voting_start_time":"2022-06-10T13:49:16.069169911Z","voting_end_time":"2022-06-12T13:49:16.069169911Z","metadata":""}]
 
     def getLatestProposals(self):
-        return self.latestProposals
+        return [p for p in self.latestProposals if p["status"] == "PROPOSAL_STATUS_VOTING_PERIOD"]
 
 class MockChainTendermint1(MockChain):
     latestProposals = [{"proposal_id":"2","content":{"@type":"/ibc.core.client.v1.ClientUpdateProposal","title":"upgrade client","description":"upgrade light client","subject_client_id":"07-tendermint-0","substitute_client_id":"07-tendermint-2"},
@@ -70,7 +70,7 @@ class MockChainTendermint1(MockChain):
 		"voting_start_time":"2022-04-25T06:23:01.163682205Z","voting_end_time":"2022-04-26T06:23:01.163682205Z"}]
 
     def getLatestProposals(self):
-        return self.latestProposals
+        return [p for p in self.latestProposals if p["status"] == "PROPOSAL_STATUS_VOTING_PERIOD"]
 
 class MockChainTendermint2(MockChain):
     latestProposals = [{"proposal_id":"1","content":{"@type":"/ibc.core.client.v1.ClientUpdateProposal","title":"upgrade client","description":"upgrade light client","subject_client_id":"07-tendermint-0","substitute_client_id":"07-tendermint-2"},
@@ -78,7 +78,7 @@ class MockChainTendermint2(MockChain):
 		"voting_start_time":"2022-04-25T06:23:01.163682205Z","voting_end_time":"2022-04-26T06:23:01.163682205Z"}]
 
     def getLatestProposals(self):
-        return self.latestProposals
+        return [p for p in self.latestProposals if p["status"] == "PROPOSAL_STATUS_VOTING_PERIOD"]
 
 class MockChainTendermint3(MockChain):
     latestProposals = [{"proposal_id":"3","content":{"@type":"/ibc.core.client.v1.ClientUpdateProposal","title":"Increase Signed Blocks Window Parameter to 2880","description":"upgrade light client","subject_client_id":"07-tendermint-0","substitute_client_id":"07-tendermint-2"},
@@ -90,7 +90,7 @@ class MockChainTendermint3(MockChain):
 		"voting_start_time":"2022-04-25T06:23:01.163682205Z","voting_end_time":"2022-04-26T06:23:01.163682205Z"}]
 
     def getLatestProposals(self):
-        return self.latestProposals
+        return [p for p in self.latestProposals if p["status"] == "PROPOSAL_STATUS_VOTING_PERIOD"]
 
 class MockChainNear(MockChain):
     EPOCHTIME = 10000

--- a/tests/mocks/mockchain.py
+++ b/tests/mocks/mockchain.py
@@ -58,26 +58,24 @@ class MockChain(Chain):
 
 
 class MockChainTendermint(MockChain):
-    latestProposals = [{"id": "1", "messages": [{"@type": "/cosmos.gov.v1.MsgExecLegacyContent",
-                                               "content": {"@type": "/cosmos.params.v1beta1.ParameterChangeProposal",
-                                                           "title": "Increase Signed Blocks Window Parameter to 2880",
-                                                           "description": "Mamaki Testnet initially started with very strict slashing conditions. This proposal changes the signed_blocks_window to about 24 hours.",
-                                                           "changes": [
-                                                               {"subspace": "slashing", "key": "SignedBlocksWindow",
-                                                                "value": "\"2880\""}]},
-                                               "authority": "celestia10d07y265gmmuvt4z0w9aw880jnsr700jtgz4v7"}],
-                      "status": "PROPOSAL_STATUS_VOTING_PERIOD",
-                      "final_tally_result": {"yes_count": "0", "abstain_count": "0", "no_count": "0",
-                                             "no_with_veto_count": "0"},
-                      "submit_time": "2022-06-10T13:43:02.649255900Z",
-                      "deposit_end_time": "2022-06-12T13:43:02.649255900Z",
-                      "total_deposit": [{"denom": "utia", "amount": "100100000"}],
-                      "voting_start_time": "2022-06-10T13:49:16.069169911Z",
-                      "voting_end_time": "2022-06-12T13:49:16.069169911Z", "metadata": ""}]
+    latestProposals = [{"proposal_id":"2","content":{"@type":"/ibc.core.client.v1.ClientUpdateProposal","title":"upgrade client","description":"upgrade light client","subject_client_id":"07-tendermint-0","substitute_client_id":"07-tendermint-2"},
+		"status":"PROPOSAL_STATUS_VOTING_PERIOD","final_tally_result":{"yes":"103022468704","abstain":"56100000","no":"115992000","no_with_veto":"90000000"},"submit_time":"2022-04-25T06:22:25.564973762Z","deposit_end_time":"2022-05-09T06:22:25.564973762Z","total_deposit":[{"denom":"ufis","amount":"1000000000"}],
+		"voting_start_time":"2022-04-25T06:23:01.163682205Z","voting_end_time":"2022-04-26T06:23:01.163682205Z"}, {"proposal_id":"1","content":{"@type":"/ibc.core.client.v1.ClientUpdateProposal","title":"upgrade client","description":"upgrade light client","subject_client_id":"07-tendermint-0","substitute_client_id":"07-tendermint-2"},
+		"status":"PROPOSAL_STATUS_FAILED","final_tally_result":{"yes":"103022468704","abstain":"56100000","no":"115992000","no_with_veto":"90000000"},"submit_time":"2022-04-25T06:22:25.564973762Z","deposit_end_time":"2022-05-09T06:22:25.564973762Z","total_deposit":[{"denom":"ufis","amount":"1000000000"}],
+		"voting_start_time":"2022-04-25T06:23:01.163682205Z","voting_end_time":"2022-04-26T06:23:01.163682205Z"}]
 
     def getLatestProposals(self):
         return self.latestProposals
 
+class MockChainTendermint1(MockChain):
+    latestProposals = [{"iproposal_idd":"2","content":{"@type":"/ibc.core.client.v1.ClientUpdateProposal","title":"upgrade client","description":"upgrade light client","subject_client_id":"07-tendermint-0","substitute_client_id":"07-tendermint-2"},
+		"status":"PROPOSAL_STATUS_FAILED","final_tally_result":{"yes":"103022468704","abstain":"56100000","no":"115992000","no_with_veto":"90000000"},"submit_time":"2022-04-25T06:22:25.564973762Z","deposit_end_time":"2022-05-09T06:22:25.564973762Z","total_deposit":[{"denom":"ufis","amount":"1000000000"}],
+		"voting_start_time":"2022-04-25T06:23:01.163682205Z","voting_end_time":"2022-04-26T06:23:01.163682205Z"}, {"proposal_id":"1","content":{"@type":"/ibc.core.client.v1.ClientUpdateProposal","title":"upgrade client","description":"upgrade light client","subject_client_id":"07-tendermint-0","substitute_client_id":"07-tendermint-2"},
+		"status":"PROPOSAL_STATUS_FAILED","final_tally_result":{"yes":"103022468704","abstain":"56100000","no":"115992000","no_with_veto":"90000000"},"submit_time":"2022-04-25T06:22:25.564973762Z","deposit_end_time":"2022-05-09T06:22:25.564973762Z","total_deposit":[{"denom":"ufis","amount":"1000000000"}],
+		"voting_start_time":"2022-04-25T06:23:01.163682205Z","voting_end_time":"2022-04-26T06:23:01.163682205Z"}]
+
+    def getLatestProposals(self):
+        return self.latestProposals
 
 class MockChainNear(MockChain):
     EPOCHTIME = 10000

--- a/tests/mocks/mockchain.py
+++ b/tests/mocks/mockchain.py
@@ -58,7 +58,7 @@ class MockChain(Chain):
 
 
 class MockChainTendermint(MockChain):
-    latestProposal = {"id": "1", "messages": [{"@type": "/cosmos.gov.v1.MsgExecLegacyContent",
+    latestProposals = [{"id": "1", "messages": [{"@type": "/cosmos.gov.v1.MsgExecLegacyContent",
                                                "content": {"@type": "/cosmos.params.v1beta1.ParameterChangeProposal",
                                                            "title": "Increase Signed Blocks Window Parameter to 2880",
                                                            "description": "Mamaki Testnet initially started with very strict slashing conditions. This proposal changes the signed_blocks_window to about 24 hours.",
@@ -73,10 +73,10 @@ class MockChainTendermint(MockChain):
                       "deposit_end_time": "2022-06-12T13:43:02.649255900Z",
                       "total_deposit": [{"denom": "utia", "amount": "100100000"}],
                       "voting_start_time": "2022-06-10T13:49:16.069169911Z",
-                      "voting_end_time": "2022-06-12T13:49:16.069169911Z", "metadata": ""}
+                      "voting_end_time": "2022-06-12T13:49:16.069169911Z", "metadata": ""}]
 
-    def getLatestProposal(self):
-        return self.latestProposal
+    def getLatestProposals(self):
+        return self.latestProposals
 
 
 class MockChainNear(MockChain):

--- a/tests/task_tendermint_test.py
+++ b/tests/task_tendermint_test.py
@@ -40,4 +40,4 @@ class TestTaskTendermintNewProposal(unittest.TestCase):
 		t.run()
 		n.flush()
 		self.assertEqual(len(n.events), 1)
-		self.assertEqual(n.events[0], urllib.parse.quote('#got new proposal: Increase Signed Blocks Window Parameter to 2880 '+ Emoji.Proposal + ' '))
+		self.assertEqual(n.events[0], urllib.parse.quote('#got new proposal: Increase Signed Blocks Window Parameter to 2880 ' + Emoji.Proposal + ' '))

--- a/tests/task_tendermint_test.py
+++ b/tests/task_tendermint_test.py
@@ -40,7 +40,7 @@ class TestTaskTendermintNewProposal(unittest.TestCase):
 		t.run()
 		n.flush()
 		self.assertEqual(len(n.events), 1)
-		self.assertEqual(n.events[0], urllib.parse.quote('#got new proposal: upgrade client ' + Emoji.Proposal + ' '))
+		self.assertEqual(n.events[0], urllib.parse.quote('#got 1 new proposal: upgrade client ' + Emoji.Proposal + ' '))
 
 	def test_alert_first_run(self):
 		c, n, t, s = buildTaskEnv(TaskTendermintNewProposal, MockChainTendermint2)
@@ -57,4 +57,4 @@ class TestTaskTendermintNewProposal(unittest.TestCase):
 		t.run()
 		n.flush()
 		self.assertEqual(len(n.events), 1)
-		self.assertEqual(n.events[0], urllib.parse.quote('#got new proposal: upgrade client ' + Emoji.Proposal + ' '))
+		self.assertEqual(n.events[0], urllib.parse.quote('#got 2 new proposal: Increase Signed Blocks Window Parameter to 2880' + '\n' + 'upgrade client ' + Emoji.Proposal + ' '))

--- a/tests/task_tendermint_test.py
+++ b/tests/task_tendermint_test.py
@@ -26,7 +26,7 @@ class TestTaskTendermintHealthError(unittest.TestCase):
 class TestTaskTendermintNewProposal(unittest.TestCase):
 	def test_noalert(self):
 		c, n, t, s = buildTaskEnv(TaskTendermintNewProposal, MockChainTendermint)
-		t.prev = {"id":"1","messages":[{"@type":"/cosmos.gov.v1.MsgExecLegacyContent","content":{"@type":"/cosmos.params.v1beta1.ParameterChangeProposal","title":"Increase Signed Blocks Window Parameter to 2880","description":"Mamaki Testnet initially started with very strict slashing conditions. This proposal changes the signed_blocks_window to about 24 hours.","changes":[{"subspace":"slashing","key":"SignedBlocksWindow","value":"\"2880\""}]},"authority":"celestia10d07y265gmmuvt4z0w9aw880jnsr700jtgz4v7"}],"status":"PROPOSAL_STATUS_VOTING_PERIOD","final_tally_result":{"yes_count":"0","abstain_count":"0","no_count":"0","no_with_veto_count":"0"},"submit_time":"2022-06-10T13:43:02.649255900Z","deposit_end_time":"2022-06-12T13:43:02.649255900Z","total_deposit":[{"denom":"utia","amount":"100100000"}],"voting_start_time":"2022-06-10T13:49:16.069169911Z","voting_end_time":"2022-06-12T13:49:16.069169911Z","metadata":""}
+		t.prev = [{"id":"1","messages":[{"@type":"/cosmos.gov.v1.MsgExecLegacyContent","content":{"@type":"/cosmos.params.v1beta1.ParameterChangeProposal","title":"Increase Signed Blocks Window Parameter to 2880","description":"Mamaki Testnet initially started with very strict slashing conditions. This proposal changes the signed_blocks_window to about 24 hours.","changes":[{"subspace":"slashing","key":"SignedBlocksWindow","value":"\"2880\""}]},"authority":"celestia10d07y265gmmuvt4z0w9aw880jnsr700jtgz4v7"}],"status":"PROPOSAL_STATUS_VOTING_PERIOD","final_tally_result":{"yes_count":"0","abstain_count":"0","no_count":"0","no_with_veto_count":"0"},"submit_time":"2022-06-10T13:43:02.649255900Z","deposit_end_time":"2022-06-12T13:43:02.649255900Z","total_deposit":[{"denom":"utia","amount":"100100000"}],"voting_start_time":"2022-06-10T13:49:16.069169911Z","voting_end_time":"2022-06-12T13:49:16.069169911Z","metadata":""}]
 		t.run()
 		n.flush()
 		print(n.events)
@@ -34,9 +34,9 @@ class TestTaskTendermintNewProposal(unittest.TestCase):
 
 	def test_alert(self):
 		c, n, t, s = buildTaskEnv(TaskTendermintNewProposal, MockChainTendermint)
-		t.prev = {"id":"2","content":{"@type":"/ibc.core.client.v1.ClientUpdateProposal","title":"upgrade client","description":"upgrade light client","subject_client_id":"07-tendermint-0","substitute_client_id":"07-tendermint-2"},
+		t.prev = [{"id":"2","content":{"@type":"/ibc.core.client.v1.ClientUpdateProposal","title":"upgrade client","description":"upgrade light client","subject_client_id":"07-tendermint-0","substitute_client_id":"07-tendermint-2"},
 		"status":"PROPOSAL_STATUS_FAILED","final_tally_result":{"yes":"103022468704","abstain":"56100000","no":"115992000","no_with_veto":"90000000"},"submit_time":"2022-04-25T06:22:25.564973762Z","deposit_end_time":"2022-05-09T06:22:25.564973762Z","total_deposit":[{"denom":"ufis","amount":"1000000000"}],
-		"voting_start_time":"2022-04-25T06:23:01.163682205Z","voting_end_time":"2022-04-26T06:23:01.163682205Z"}
+		"voting_start_time":"2022-04-25T06:23:01.163682205Z","voting_end_time":"2022-04-26T06:23:01.163682205Z"}]
 		t.run()
 		n.flush()
 		self.assertEqual(len(n.events), 1)

--- a/tests/task_tendermint_test.py
+++ b/tests/task_tendermint_test.py
@@ -3,7 +3,7 @@ import urllib.parse
 
 from srvcheck.notification.notification import Emoji
 from srvcheck.chains.tendermint import TaskTendermintHealthError, TaskTendermintNewProposal
-from tests.mocks.mockchain import MockChainTendermint, MockChainTendermint1
+from tests.mocks.mockchain import MockChainTendermint, MockChainTendermint1, MockChainTendermint2, MockChainTendermint3
 from .task_test import buildTaskEnv
 
 class TestTaskTendermintHealthError(unittest.TestCase):
@@ -33,7 +33,7 @@ class TestTaskTendermintNewProposal(unittest.TestCase):
 		self.assertEqual(len(n.events), 0)
 
 	def test_alert(self):
-		c, n, t, s = buildTaskEnv(TaskTendermintNewProposal, MockChainTendermint)
+		c, n, t, s = buildTaskEnv(TaskTendermintNewProposal, MockChainTendermint1)
 		t.prev = [{"proposal_id":"1","content":{"@type":"/ibc.core.client.v1.ClientUpdateProposal","title":"upgrade client","description":"upgrade light client","subject_client_id":"07-tendermint-0","substitute_client_id":"07-tendermint-2"},
 		"status":"PROPOSAL_STATUS_FAILED","final_tally_result":{"yes":"103022468704","abstain":"56100000","no":"115992000","no_with_veto":"90000000"},"submit_time":"2022-04-25T06:22:25.564973762Z","deposit_end_time":"2022-05-09T06:22:25.564973762Z","total_deposit":[{"denom":"ufis","amount":"1000000000"}],
 		"voting_start_time":"2022-04-25T06:23:01.163682205Z","voting_end_time":"2022-04-26T06:23:01.163682205Z"}]
@@ -42,12 +42,19 @@ class TestTaskTendermintNewProposal(unittest.TestCase):
 		self.assertEqual(len(n.events), 1)
 		self.assertEqual(n.events[0], urllib.parse.quote('#got new proposal: upgrade client ' + Emoji.Proposal + ' '))
 
-	def test_noalert_no_voting_period(self):
-		c, n, t, s = buildTaskEnv(TaskTendermintNewProposal, MockChainTendermint1)
-		t.prev = [{"proposal_id":"1","content":{"@type":"/ibc.core.client.v1.ClientUpdateProposal","title":"upgrade client","description":"upgrade light client","subject_client_id":"07-tendermint-0","substitute_client_id":"07-tendermint-2"},
-		"status":"PROPOSAL_STATUS_FAILED","final_tally_result":{"yes":"103022468704","abstain":"56100000","no":"115992000","no_with_veto":"90000000"},"submit_time":"2022-04-25T06:22:25.564973762Z","deposit_end_time":"2022-05-09T06:22:25.564973762Z","total_deposit":[{"denom":"ufis","amount":"1000000000"}],
-		"voting_start_time":"2022-04-25T06:23:01.163682205Z","voting_end_time":"2022-04-26T06:23:01.163682205Z"}]		
+	def test_alert_first_run(self):
+		c, n, t, s = buildTaskEnv(TaskTendermintNewProposal, MockChainTendermint2)
 		t.run()
 		n.flush()
-		print(n.events)
-		self.assertEqual(len(n.events), 0)
+		self.assertEqual(len(n.events), 1)
+		self.assertEqual(n.events[0], urllib.parse.quote('#got latest proposal: upgrade client ' + Emoji.Proposal + ' '))
+
+	def test_alert_multiple_proposals(self):
+		c, n, t, s = buildTaskEnv(TaskTendermintNewProposal, MockChainTendermint3)
+		t.prev = [{"proposal_id":"1","content":{"@type":"/ibc.core.client.v1.ClientUpdateProposal","title":"upgrade client","description":"upgrade light client","subject_client_id":"07-tendermint-0","substitute_client_id":"07-tendermint-2"},
+		"status":"PROPOSAL_STATUS_FAILED","final_tally_result":{"yes":"103022468704","abstain":"56100000","no":"115992000","no_with_veto":"90000000"},"submit_time":"2022-04-25T06:22:25.564973762Z","deposit_end_time":"2022-05-09T06:22:25.564973762Z","total_deposit":[{"denom":"ufis","amount":"1000000000"}],
+		"voting_start_time":"2022-04-25T06:23:01.163682205Z","voting_end_time":"2022-04-26T06:23:01.163682205Z"}]
+		t.run()
+		n.flush()
+		self.assertEqual(len(n.events), 1)
+		self.assertEqual(n.events[0], urllib.parse.quote('#got new proposal: upgrade client ' + Emoji.Proposal + ' '))

--- a/tests/task_tendermint_test.py
+++ b/tests/task_tendermint_test.py
@@ -3,7 +3,7 @@ import urllib.parse
 
 from srvcheck.notification.notification import Emoji
 from srvcheck.chains.tendermint import TaskTendermintHealthError, TaskTendermintNewProposal
-from tests.mocks.mockchain import MockChainTendermint
+from tests.mocks.mockchain import MockChainTendermint, MockChainTendermint1
 from .task_test import buildTaskEnv
 
 class TestTaskTendermintHealthError(unittest.TestCase):
@@ -32,22 +32,22 @@ class TestTaskTendermintNewProposal(unittest.TestCase):
 		print(n.events)
 		self.assertEqual(len(n.events), 0)
 
-	def test_noalert_no_voting_period(self):
+	def test_alert(self):
 		c, n, t, s = buildTaskEnv(TaskTendermintNewProposal, MockChainTendermint)
-		t.prev = [{"id":"2","content":{"@type":"/ibc.core.client.v1.ClientUpdateProposal","title":"upgrade client","description":"upgrade light client","subject_client_id":"07-tendermint-0","substitute_client_id":"07-tendermint-2"},
+		t.prev = [{"proposal_id":"1","content":{"@type":"/ibc.core.client.v1.ClientUpdateProposal","title":"upgrade client","description":"upgrade light client","subject_client_id":"07-tendermint-0","substitute_client_id":"07-tendermint-2"},
+		"status":"PROPOSAL_STATUS_FAILED","final_tally_result":{"yes":"103022468704","abstain":"56100000","no":"115992000","no_with_veto":"90000000"},"submit_time":"2022-04-25T06:22:25.564973762Z","deposit_end_time":"2022-05-09T06:22:25.564973762Z","total_deposit":[{"denom":"ufis","amount":"1000000000"}],
+		"voting_start_time":"2022-04-25T06:23:01.163682205Z","voting_end_time":"2022-04-26T06:23:01.163682205Z"}]
+		t.run()
+		n.flush()
+		self.assertEqual(len(n.events), 1)
+		self.assertEqual(n.events[0], urllib.parse.quote('#got new proposal: upgrade client ' + Emoji.Proposal + ' '))
+
+	def test_noalert_no_voting_period(self):
+		c, n, t, s = buildTaskEnv(TaskTendermintNewProposal, MockChainTendermint1)
+		t.prev = [{"proposal_id":"1","content":{"@type":"/ibc.core.client.v1.ClientUpdateProposal","title":"upgrade client","description":"upgrade light client","subject_client_id":"07-tendermint-0","substitute_client_id":"07-tendermint-2"},
 		"status":"PROPOSAL_STATUS_FAILED","final_tally_result":{"yes":"103022468704","abstain":"56100000","no":"115992000","no_with_veto":"90000000"},"submit_time":"2022-04-25T06:22:25.564973762Z","deposit_end_time":"2022-05-09T06:22:25.564973762Z","total_deposit":[{"denom":"ufis","amount":"1000000000"}],
 		"voting_start_time":"2022-04-25T06:23:01.163682205Z","voting_end_time":"2022-04-26T06:23:01.163682205Z"}]		
 		t.run()
 		n.flush()
 		print(n.events)
 		self.assertEqual(len(n.events), 0)
-
-	def test_alert(self):
-		c, n, t, s = buildTaskEnv(TaskTendermintNewProposal, MockChainTendermint)
-		t.prev = [{"id":"2","content":{"@type":"/ibc.core.client.v1.ClientUpdateProposal","title":"upgrade client","description":"upgrade light client","subject_client_id":"07-tendermint-0","substitute_client_id":"07-tendermint-2"},
-		"status":"PROPOSAL_STATUS_VOTING_PERIOD","final_tally_result":{"yes":"103022468704","abstain":"56100000","no":"115992000","no_with_veto":"90000000"},"submit_time":"2022-04-25T06:22:25.564973762Z","deposit_end_time":"2022-05-09T06:22:25.564973762Z","total_deposit":[{"denom":"ufis","amount":"1000000000"}],
-		"voting_start_time":"2022-04-25T06:23:01.163682205Z","voting_end_time":"2022-04-26T06:23:01.163682205Z"}]
-		t.run()
-		n.flush()
-		self.assertEqual(len(n.events), 1)
-		self.assertEqual(n.events[0], urllib.parse.quote('#got new proposal: upgrade client ' + Emoji.Proposal + ' '))

--- a/tests/task_tendermint_test.py
+++ b/tests/task_tendermint_test.py
@@ -32,10 +32,20 @@ class TestTaskTendermintNewProposal(unittest.TestCase):
 		print(n.events)
 		self.assertEqual(len(n.events), 0)
 
-	def test_alert(self):
+	def test_noalert_no_voting_period(self):
 		c, n, t, s = buildTaskEnv(TaskTendermintNewProposal, MockChainTendermint)
 		t.prev = [{"id":"2","content":{"@type":"/ibc.core.client.v1.ClientUpdateProposal","title":"upgrade client","description":"upgrade light client","subject_client_id":"07-tendermint-0","substitute_client_id":"07-tendermint-2"},
 		"status":"PROPOSAL_STATUS_FAILED","final_tally_result":{"yes":"103022468704","abstain":"56100000","no":"115992000","no_with_veto":"90000000"},"submit_time":"2022-04-25T06:22:25.564973762Z","deposit_end_time":"2022-05-09T06:22:25.564973762Z","total_deposit":[{"denom":"ufis","amount":"1000000000"}],
+		"voting_start_time":"2022-04-25T06:23:01.163682205Z","voting_end_time":"2022-04-26T06:23:01.163682205Z"}]		
+		t.run()
+		n.flush()
+		print(n.events)
+		self.assertEqual(len(n.events), 0)
+
+	def test_alert(self):
+		c, n, t, s = buildTaskEnv(TaskTendermintNewProposal, MockChainTendermint)
+		t.prev = [{"id":"2","content":{"@type":"/ibc.core.client.v1.ClientUpdateProposal","title":"upgrade client","description":"upgrade light client","subject_client_id":"07-tendermint-0","substitute_client_id":"07-tendermint-2"},
+		"status":"PROPOSAL_STATUS_VOTING_PERIOD","final_tally_result":{"yes":"103022468704","abstain":"56100000","no":"115992000","no_with_veto":"90000000"},"submit_time":"2022-04-25T06:22:25.564973762Z","deposit_end_time":"2022-05-09T06:22:25.564973762Z","total_deposit":[{"denom":"ufis","amount":"1000000000"}],
 		"voting_start_time":"2022-04-25T06:23:01.163682205Z","voting_end_time":"2022-04-26T06:23:01.163682205Z"}]
 		t.run()
 		n.flush()

--- a/tests/task_tendermint_test.py
+++ b/tests/task_tendermint_test.py
@@ -50,4 +50,4 @@ class TestTaskTendermintNewProposal(unittest.TestCase):
 		t.run()
 		n.flush()
 		self.assertEqual(len(n.events), 1)
-		self.assertEqual(n.events[0], urllib.parse.quote('#got new proposal: Increase Signed Blocks Window Parameter to 2880 ' + Emoji.Proposal + ' '))
+		self.assertEqual(n.events[0], urllib.parse.quote('#got new proposal: upgrade client ' + Emoji.Proposal + ' '))


### PR DESCRIPTION
Added new tasks for the monitoring of _**Aptos**_ nodes:
- **TaskAptosValidatorPerformanceCheck**, used to monitor the performance of the node in term of the increase of the active stake and also number of proposals submitted and failed in the previous epoch
- **TaskAptosConnectedToFullNodeCheck**, used to check if the validator node is connected to the validator full node (vfn)
- **TaskAptosConnectedToAptosNodeCheck**, used to check if the node is connected to the aptos node
- **TaskAptosStateSyncCheck**, used to check if the node is state synching correctly

Added and modified tasks for the monitoring of the performance of _**Substrate**_ nodes:
- **TaskBlockProductionReport**, used to monitor the performance of a standard Substrate node (like Kusama, Polkadot, Aleph Zero) in term of block produced and missed in the previous era
- **TaskBlockProductionReportParachain**, used to monitor the performance of a parachain node (like Moonbeam, Moonriver, Shiden and Mangata) in term of block produced and missed in the previous session

**Bug** fixed and misc **changes**:
- Fixed **TaskTendermintNewProposal**, task used to get all the new proposals in the voting period (that haven't been already read) for the _**Tendermint**_ nodes, this task before was able only to get the latest proposal
- Fixed **TaskChainStuck**, that also notified when it shouldn't due to duplicate checks
- Changed the installer param to specify the validator address, it was `-c` now it is `-a`, changed also the name of the config variabile in the config file, it was `collatorAddress`, now it is `validatorAddress`
- Fixed bug with the **installer** for the `mountPoint` config variable that wasn't reading well the parameter passed due to the bad char `\`
- Fixed bug with the function **`isSynching`** of the _**Substrate**_ nodes
- Various fixes due to changes to the **_Aptos_** rpc methods