### PR TITLE
Modular support to Parachains and blocks production charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Substrate specific tasks:
 - TaskSubstrateNewReferenda
 - TaskBlockProductionCheck
 - TaskBlockProductionReport
+- TaskBlockProductionReportCharts
 
 Near specific tasks:
 - TaskNearBlockMissed
@@ -75,14 +76,13 @@ install --help
  -a  --validator-address <address> enable checks on block production
  -b  --block-time <time> expected block time [default is 60 seconds]
      --branch <name> name of the branch to use for the installation [default is main]
-     --git <git_api> git api to query the latest realease version installed
-     --rel <version> release version installed (required for tendermint chain if git_api is specified)
- -t  --telegram <chat_id> <token> telegram chat options (id and token) where the alerts will be sent [required]
+     --git <git_api> git api to query the latest realease version installed     
+     --gov enable checks on new governance proposals (tendermint)
      --mount <mount_point> mount point where the node is installed
  -n  --name <name> monitor name [default is the server hostname]
-     --signed-blocks <max_misses> <blocks_window> max number of blocks not signed in a specified blocks window [default is 5 blocks missed out of the latest 100 blocks]
+     --rel <version> release version installed (required for tendermint chain if git_api is specified)          --signed-blocks <max_misses> <blocks_window> max number of blocks not signed in a specified blocks window [default is 5 blocks missed out of the latest 100 blocks]
  -s  --service <name> service name of the node to monitor [required]
-     --gov enable checks on new governance proposals (tendermint)
+ -t  --telegram <chat_id> <token> telegram chat options (id and token) where the alerts will be sent [required]
  -v  --verbose enable verbose installation
 ```
 

--- a/conf/srvcheck.conf
+++ b/conf/srvcheck.conf
@@ -31,8 +31,6 @@ localVersion =
 validatorAddress = 
 ; mount point
 mountPoint = 
-; parachain id
-parachainId = 
 
 ; task specific settings
 [tasks]

--- a/conf/srvcheck.conf
+++ b/conf/srvcheck.conf
@@ -31,6 +31,8 @@ localVersion =
 validatorAddress = 
 ; mount point
 mountPoint = 
+; parachain id
+parachainId = 
 
 ; task specific settings
 [tasks]

--- a/install.sh
+++ b/install.sh
@@ -22,10 +22,10 @@ print_help () {
      --gov enable checks on new governance proposals (tendermint)
      --mount <mount_point> mount point where the node is installed
  -n  --name <name> monitor name [default is the server hostname]
- -t  --telegram <chat_id> <token> telegram chat options (id and token) where the alerts will be sent [required]
      --rel <version> release version installed (required for tendermint chain if git_api is specified)
      --signed-blocks <max_misses> <blocks_window> max number of blocks not signed in a specified blocks window [default is 5 blocks missed out of the latest 100 blocks]
  -s  --service <name> service name of the node to monitor [required]
+ -t  --telegram <chat_id> <token> telegram chat options (id and token) where the alerts will be sent [required]
  -v  --verbose enable verbose installation"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -17,15 +17,15 @@ print_help () {
  -a  --validator-address <address> enable checks on block production
  -b  --block-time <time> expected block time [default is 60 seconds]
      --branch <name> name of the branch to use for the installation [default is main]
+     --endpoint <url:port> node local rpc address
      --git <git_api> git api to query the latest realease version installed
-     --rel <version> release version installed (required for tendermint chain if git_api is specified)
- -t  --telegram <chat_id> <token> telegram chat options (id and token) where the alerts will be sent [required]
+     --gov enable checks on new governance proposals (tendermint)
      --mount <mount_point> mount point where the node is installed
  -n  --name <name> monitor name [default is the server hostname]
+ -t  --telegram <chat_id> <token> telegram chat options (id and token) where the alerts will be sent [required]
+     --rel <version> release version installed (required for tendermint chain if git_api is specified)
      --signed-blocks <max_misses> <blocks_window> max number of blocks not signed in a specified blocks window [default is 5 blocks missed out of the latest 100 blocks]
  -s  --service <name> service name of the node to monitor [required]
-     --gov enable checks on new governance proposals (tendermint)
-     --parachain-id <id> parachain id (substrate)
  -v  --verbose enable verbose installation"
 }
 
@@ -67,6 +67,10 @@ install_monitor () {
     if [ ! -z "$mountPoint" ]
     then
         sed -i -e "s,^mountPoint =.*,mountPoint = $mountPoint,g" $config_file
+    fi
+    if [ ! -z "$endpoint" ]
+    then
+        sed -i -e "s,^endpoint =.*,endpoint = $endpoint,g" $config_file
     fi
     if [[ ! -z "$threshold_notsigned" && ! -z "$block_window" ]]
     then
@@ -194,11 +198,6 @@ case $1 in
         shift # past value
         shift # past value
     ;;
-    --parachain-id)
-        id="$2"
-        shift # past argument
-        shift # past value
-    ;;
     --active-set)
         if [[ -z $2 ]]
         then
@@ -217,6 +216,17 @@ case $1 in
             exit 1
         else
             service="$2"
+        fi
+        shift # past argument
+        shift # past value
+    ;;
+    --endpoint)
+        if [[ -z $2 ]]
+        then
+            print_help
+            exit 1
+        else
+	        endpoint="$2"
         fi
         shift # past argument
         shift # past value

--- a/install.sh
+++ b/install.sh
@@ -73,11 +73,6 @@ install_monitor () {
         sed -i -e "s/^thresholdNotsigned =.*/thresholdNotsigned = $threshold_notsigned/" $config_file
         sed -i -e "s/^blockWindow =.*/blockWindow = $block_window/" $config_file
     fi
-    if [ ! -z "$id" ]
-    then
-        sed -i -e "s/^parachainId =.*/parachainId = $id/" $config_file
-    fi
-    
     if [ "$enable_gov" = true ]
     then
         sed -i -r 's/(.TaskTendermintNewProposal?;|.TaskTendermintNewProposal?;?$)//' $config_file #enable checks on tendermint governance module

--- a/install.sh
+++ b/install.sh
@@ -25,6 +25,7 @@ print_help () {
      --signed-blocks <max_misses> <blocks_window> max number of blocks not signed in a specified blocks window [default is 5 blocks missed out of the latest 100 blocks]
  -s  --service <name> service name of the node to monitor [required]
      --gov enable checks on new governance proposals (tendermint)
+     --parachain-id <id> parachain id (substrate)
  -v  --verbose enable verbose installation"
 }
 
@@ -72,6 +73,11 @@ install_monitor () {
         sed -i -e "s/^thresholdNotsigned =.*/thresholdNotsigned = $threshold_notsigned/" $config_file
         sed -i -e "s/^blockWindow =.*/blockWindow = $block_window/" $config_file
     fi
+    if [ ! -z "$id" ]
+    then
+        sed -i -e "s/^parachainId =.*/parachainId = $id/" $config_file
+    fi
+    
     if [ "$enable_gov" = true ]
     then
         sed -i -r 's/(.TaskTendermintNewProposal?;|.TaskTendermintNewProposal?;?$)//' $config_file #enable checks on tendermint governance module
@@ -191,6 +197,11 @@ case $1 in
         block_window="$3"
         shift # past argument
         shift # past value
+        shift # past value
+    ;;
+    --parachain-id)
+        id="$2"
+        shift # past argument
         shift # past value
     ;;
     --active-set)

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ setup(name='srvcheck',
 		],
 	},
     zip_safe=False,
-	install_requires=['requests', 'substrate-interface', 'packaging>=20.0', 'python-dateutil', 'matplotlib'],
+	install_requires=['requests', 'substrate-interface', 'packaging==21.3', 'python-dateutil', 'matplotlib'],
 )

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ setup(name='srvcheck',
 		],
 	},
     zip_safe=False,
-	install_requires=['requests', 'substrate-interface', 'packaging', 'python-dateutil', 'matplotlib'],
+	install_requires=['requests', 'substrate-interface', 'packaging>=20.0', 'python-dateutil', 'matplotlib'],
 )

--- a/srvcheck/chains/__init__.py
+++ b/srvcheck/chains/__init__.py
@@ -13,4 +13,4 @@ from .mangata import Mangata
 from .moonbeam import Moonbeam
 from .t3rn import T3rn
 
-CHAINS = [Substrate, Tendermint, Tezos, Lisk, Solana, Aptos, Near, Amplitude, Astar, Mangata, Moonbeam]
+CHAINS = [Substrate, Tendermint, Tezos, Lisk, Solana, Aptos, Near, Amplitude, Astar, Mangata, Moonbeam, T3rn]

--- a/srvcheck/chains/__init__.py
+++ b/srvcheck/chains/__init__.py
@@ -7,5 +7,6 @@ from .tezos import Tezos
 from .solana import Solana
 from .aptos import Aptos
 from .near import Near
+from .amplitude import Amplitude
 
-CHAINS = [Substrate, Tendermint, Tezos, Lisk, Solana, Aptos, Near]
+CHAINS = [Substrate, Tendermint, Tezos, Lisk, Solana, Aptos, Near, Amplitude]

--- a/srvcheck/chains/__init__.py
+++ b/srvcheck/chains/__init__.py
@@ -11,5 +11,6 @@ from .amplitude import Amplitude
 from .astar import Astar
 from .mangata import Mangata
 from .moonbeam import Moonbeam
+from .t3rn import T3rn
 
 CHAINS = [Substrate, Tendermint, Tezos, Lisk, Solana, Aptos, Near, Amplitude, Astar, Mangata, Moonbeam]

--- a/srvcheck/chains/__init__.py
+++ b/srvcheck/chains/__init__.py
@@ -8,5 +8,8 @@ from .solana import Solana
 from .aptos import Aptos
 from .near import Near
 from .amplitude import Amplitude
+from .astar import Astar
+from .mangata import Mangata
+from .moonbeam import Moonbeam
 
-CHAINS = [Substrate, Tendermint, Tezos, Lisk, Solana, Aptos, Near, Amplitude]
+CHAINS = [Substrate, Tendermint, Tezos, Lisk, Solana, Aptos, Near, Amplitude, Astar, Mangata, Moonbeam]

--- a/srvcheck/chains/amplitude.py
+++ b/srvcheck/chains/amplitude.py
@@ -67,7 +67,7 @@ class Amplitude(Substrate):
 	def detect(conf):
 		try:
 			Amplitude(conf).getVersion()
-			return Amplitude(conf).isParachain() and int(Amplitude(conf).getParachainId()) == int(conf.getOrDefault('chain.parachainId'))
+			return Amplitude(conf).isParachain() and Amplitude(conf).getNodeName() == "Pendulum Collator"
 		except:
 			return False
 

--- a/srvcheck/chains/amplitude.py
+++ b/srvcheck/chains/amplitude.py
@@ -25,7 +25,7 @@ class TaskBlockProductionReportParachain(Task):
 			self.prev = session
 
 		if self.s.chain.isCollating():
-			startingRoundBlock = session
+			startingRoundBlock = self.s.chain.getRoundInfo()['first']
 			currentBlock = self.s.chain.getHeight()
 			blocksToCheck = [b for b in self.s.chain.getExpectedBlocks() if b <= currentBlock and (self.lastBlockChecked is None or b > self.lastBlockChecked) and b >= startingRoundBlock]
 			for b in blocksToCheck:
@@ -70,6 +70,11 @@ class Amplitude(Substrate):
 			return Amplitude(conf).isParachain() and Amplitude(conf).getNodeName() == "Pendulum Collator"
 		except:
 			return False
+
+	def getRoundInfo(self):
+		si = self.getSubstrateInterface()
+		result = si.query(module='ParachainStaking', storage_function='Round', params=[])
+		return result.value
 
 	def isCollating(self):
 		collator = self.conf.getOrDefault('chain.validatorAddress')

--- a/srvcheck/chains/amplitude.py
+++ b/srvcheck/chains/amplitude.py
@@ -1,0 +1,86 @@
+from ..tasks import Task
+from .substrate import Substrate
+from .substrate import TaskRelayChainStuck
+from srvcheck.tasks.task import hours, minutes
+from ..utils import ConfItem, ConfSet, Bash
+from ..notification import Emoji
+
+class TaskBlockProductionReportParachain(Task):
+    def __init__(self, services, checkEvery=minutes(10), notifyEvery=hours(1)):
+        super().__init__('TaskBlockProductionReportParachain',
+                    services, checkEvery, notifyEvery)
+        self.prev = None
+        self.prevBlock = None
+        self.lastBlockChecked = None
+        self.totalBlockChecked = 0
+        self.oc = 0
+
+    @staticmethod
+    def isPluggable(services):
+        return services.chain.isParachain()
+
+    def run(self):
+        session = self.s.chain.getSession()
+        
+        if self.prev is None:
+            self.prev = session
+
+        block = 0
+        if self.s.chain.isCollating():
+            if block == -1:
+                startingRoundBlock = session
+                currentBlock = self.s.chain.getHeight()
+                blocksToCheck = [b for b in self.s.chain.getExpectedBlocks() if b <= currentBlock and (self.lastBlockChecked is None or b > self.lastBlockChecked) and b >= startingRoundBlock]
+                for b in blocksToCheck:
+                    a = self.s.chain.getBlockAuthor(b)
+                    collator = self.s.conf.getOrDefault('chain.validatorAddress')
+                    if a.lower() == collator.lower():
+                        self.oc += 1
+                    self.lastBlockChecked = b
+                    self.totalBlockChecked += 1
+
+        if self.prev != session:
+            self.prev = session
+            report = f'{self.oc} block produced last session'
+            if self.totalBlockChecked > 0:
+                report = f'{report} out of {self.totalBlockChecked} ({self.oc / self.totalBlockChecked * 100:.2f} %)'
+                self.totalBlockChecked = 0
+            report = f'{report} {Emoji.BlockProd}'
+            self.oc = 0
+            if self.s.chain.isValidator():
+                return self.notify(f'will validate during the session {session + 1} {Emoji.Leader}\n{report}')
+            elif block != -1:
+                return self.notify(f'will not validate during the session {session + 1} {Emoji.NoLeader}\n{report}')
+            else:
+                return self.notify(report)
+        return False
+
+class Amplitude(Substrate):
+    TYPE = "parachain"
+    CUSTOM_TASKS = [TaskRelayChainStuck, TaskBlockProductionReportParachain]
+
+    def __init__(self, conf):
+        super().__init__(conf)
+
+    @staticmethod
+    def detect(conf):
+        try:
+            Amplitude(conf).getVersion()
+            return Amplitude(conf).isParachain()
+        except:
+            return False
+
+    def getSession(self):
+        si = self.getSubstrateInterface()
+        result = si.query(module='Session', storage_function='CurrentIndex', params=[])
+        return result.value
+
+    def isCollating(self):
+        collator = self.conf.getOrDefault('chain.validatorAddress')
+        if collator:
+            si = self.getSubstrateInterface()
+            result = si.query(module='ParachainStaking', storage_function='TopCandidates', params=[])
+            for c in result.value:
+                if c["owner"].lower() == collator.lower():
+                    return True
+        return False

--- a/srvcheck/chains/amplitude.py
+++ b/srvcheck/chains/amplitude.py
@@ -2,7 +2,6 @@ from srvcheck.tasks.task import hours, minutes
 from ..tasks import Task
 from .substrate import Substrate
 from .substrate import TaskRelayChainStuck, TaskBlockProductionReportCharts
-from ..notification import Emoji
 
 class TaskBlockProductionReportParachain(Task):
 	def __init__(self, services, checkEvery=minutes(10), notifyEvery=hours(1)):
@@ -40,20 +39,13 @@ class TaskBlockProductionReportParachain(Task):
 			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_sessionBlocksProduced', self.prev)
 			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_blocksChecked', self.totalBlockChecked)
 			self.prev = session
-			report = f'{self.oc} block produced last session'
 			perc = 0
 			if self.totalBlockChecked > 0:
 				perc = self.oc / self.totalBlockChecked * 100
-				report = f'{report} out of {self.totalBlockChecked} ({perc:.2f} %)'
 				self.totalBlockChecked = 0
-			report = f'{report} {Emoji.BlockProd}'
 			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_blocksProduced', self.oc)
 			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_blocksPercentageProduced', perc)
 			self.oc = 0
-			if self.s.chain.isValidator():
-				return self.notify(f'will validate during the session {session + 1} {Emoji.Leader}\n{report}')
-			else:
-				return self.notify(f'will not validate during the session {session + 1} {Emoji.NoLeader}\n{report}')
 		return False
 
 class Amplitude(Substrate):

--- a/srvcheck/chains/amplitude.py
+++ b/srvcheck/chains/amplitude.py
@@ -1,52 +1,5 @@
-from srvcheck.tasks.task import hours, minutes
-from ..tasks import Task
 from .substrate import Substrate
-from .substrate import TaskRelayChainStuck, TaskBlockProductionReportCharts
-
-class TaskBlockProductionReportParachain(Task):
-	def __init__(self, services, checkEvery=minutes(10), notifyEvery=hours(1)):
-		super().__init__('TaskBlockProductionReportParachain',
-                    services, checkEvery, notifyEvery)
-		self.prev = None
-		self.prevBlock = None
-		self.lastBlockChecked = None
-		self.totalBlockChecked = 0
-		self.oc = 0
-
-	@staticmethod
-	def isPluggable(services):
-		return services.chain.isParachain()
-
-	def run(self):
-		session = self.s.chain.getSession()
-        
-		if self.prev is None:
-			self.prev = session
-
-		if self.s.chain.isCollating():
-			startingRoundBlock = self.s.chain.getRoundInfo()['first']
-			currentBlock = self.s.chain.getHeight()
-			blocksToCheck = [b for b in self.s.chain.getExpectedBlocks() if b <= currentBlock and (self.lastBlockChecked is None or b > self.lastBlockChecked) and b >= startingRoundBlock]
-			for b in blocksToCheck:
-				a = self.s.chain.getBlockAuthor(b)
-				collator = self.s.conf.getOrDefault('chain.validatorAddress')
-				if a.lower() == collator.lower():
-					self.oc += 1
-				self.lastBlockChecked = b
-				self.totalBlockChecked += 1
-
-		if self.prev != session:
-			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_sessionBlocksProduced', self.prev)
-			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_blocksChecked', self.totalBlockChecked)
-			self.prev = session
-			perc = 0
-			if self.totalBlockChecked > 0:
-				perc = self.oc / self.totalBlockChecked * 100
-				self.totalBlockChecked = 0
-			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_blocksProduced', self.oc)
-			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_blocksPercentageProduced', perc)
-			self.oc = 0
-		return False
+from .substrate import TaskRelayChainStuck, TaskBlockProductionReportParachain, TaskBlockProductionReportCharts
 
 class Amplitude(Substrate):
 	TYPE = "parachain"
@@ -77,3 +30,6 @@ class Amplitude(Substrate):
 				if c["owner"].lower() == collator.lower():
 					return True
 		return False
+
+	def getStartingRoundBlock(self):
+		return self.getRoundInfo()['first']

--- a/srvcheck/chains/amplitude.py
+++ b/srvcheck/chains/amplitude.py
@@ -22,14 +22,15 @@ class TaskBlockProductionReportChartsParachain(Task):
 		sp.data = self.s.persistent.getN(self.s.conf.getOrDefault('chain.name') + '_blocksProduced', 30)
 		sp.label = 'Produced'
 		sp.data_mod = lambda y: y
-		sp.color = 'r'
+		sp.color = 'y'
 		
 		sp.label2 = 'Produced'
 		sp.data2 = self.s.persistent.getN(self.s.conf.getOrDefault('chain.name') + '_blocksChecked', 30)
 		sp.data_mod2 = lambda y: y
-		sp.color2 = 'b'
+		sp.color2 = 'r'
 		
 		sp.share_y = True
+		sp.set_bottom_y = True
 		pc.subplots.append(sp)
 
 		sp = SubPlotConf()
@@ -37,6 +38,8 @@ class TaskBlockProductionReportChartsParachain(Task):
 		sp.label = 'Produced (%)'
 		sp.data_mod = lambda y: y
 		sp.color = 'b'
+
+		sp.set_bottom_y = True
 		pc.subplots.append(sp)
 
 		pc.fpath = '/tmp/p.png'

--- a/srvcheck/chains/amplitude.py
+++ b/srvcheck/chains/amplitude.py
@@ -67,7 +67,7 @@ class Amplitude(Substrate):
 	def detect(conf):
 		try:
 			Amplitude(conf).getVersion()
-			return Amplitude(conf).isParachain() and Amplitude(conf).getParachainId() == conf.getOrDefault('chain.parachainId')
+			return Amplitude(conf).isParachain() and int(Amplitude(conf).getParachainId()) == int(conf.getOrDefault('chain.parachainId'))
 		except:
 			return False
 

--- a/srvcheck/chains/amplitude.py
+++ b/srvcheck/chains/amplitude.py
@@ -1,86 +1,124 @@
+from srvcheck.tasks.task import hours, minutes
 from ..tasks import Task
 from .substrate import Substrate
 from .substrate import TaskRelayChainStuck
-from srvcheck.tasks.task import hours, minutes
-from ..utils import ConfItem, ConfSet, Bash
 from ..notification import Emoji
+from ..utils import savePlots, PlotsConf, SubPlotConf
 
 class TaskBlockProductionReportParachain(Task):
-    def __init__(self, services, checkEvery=minutes(10), notifyEvery=hours(1)):
-        super().__init__('TaskBlockProductionReportParachain',
+	def __init__(self, services, checkEvery=minutes(10), notifyEvery=hours(1)):
+		super().__init__('TaskBlockProductionReportParachain',
                     services, checkEvery, notifyEvery)
-        self.prev = None
-        self.prevBlock = None
-        self.lastBlockChecked = None
-        self.totalBlockChecked = 0
-        self.oc = 0
+		self.prev = None
+		self.prevBlock = None
+		self.lastBlockChecked = None
+		self.totalBlockChecked = 0
+		self.oc = 0
 
-    @staticmethod
-    def isPluggable(services):
-        return services.chain.isParachain()
+	@staticmethod
+	def isPluggable(services):
+		return services.chain.isParachain()
 
-    def run(self):
-        session = self.s.chain.getSession()
+	def run(self):
+		if self.s.persistent.hasPassedNHoursSinceLast(self.name + '_sessionBlocksProduced', 24):
+			pc = PlotsConf()
+			pc.title = self.s.conf.getOrDefault('chain.name') + " - Block production"
+			
+			sp = SubPlotConf()
+			sp.data = self.s.persistent.getN(self.name + '_blocksProduced', 30)
+			sp.label = 'Produced'
+			sp.data_mod = lambda y: y
+			sp.color = 'r'
+            
+			sp.label2 = 'Produced'
+			sp.data2 = self.s.persistent.getN(self.name + '_blocksChecked', 30)
+			sp.data_mod2 = lambda y: y
+			sp.color2 = 'b'
+            
+			sp.share_y = True
+			pc.subplots.append(sp)
+
+			sp = SubPlotConf()
+			sp.data = self.s.persistent.getN(self.name + '_blocksPercentageProduced', 30)
+			sp.label = 'Produced (%)'
+			sp.data_mod = lambda y: y
+			sp.color = 'b'
+			pc.subplots.append(sp)
+
+			pc.fpath = '/tmp/p.png'
+
+			if len(self.s.persistent.getN(self.name + '_sessionBlocksProduced', 30)) >= 2:
+				savePlots(pc, 1, 2)
+				self.s.notification.sendPhoto('/tmp/p.png')
+
+		session = self.s.chain.getSession()
         
-        if self.prev is None:
-            self.prev = session
+		if self.prev is None:
+			self.prev = session
 
-        block = 0
-        if self.s.chain.isCollating():
-            if block == -1:
-                startingRoundBlock = session
-                currentBlock = self.s.chain.getHeight()
-                blocksToCheck = [b for b in self.s.chain.getExpectedBlocks() if b <= currentBlock and (self.lastBlockChecked is None or b > self.lastBlockChecked) and b >= startingRoundBlock]
-                for b in blocksToCheck:
-                    a = self.s.chain.getBlockAuthor(b)
-                    collator = self.s.conf.getOrDefault('chain.validatorAddress')
-                    if a.lower() == collator.lower():
-                        self.oc += 1
-                    self.lastBlockChecked = b
-                    self.totalBlockChecked += 1
+		block = 0
+		if self.s.chain.isCollating():
+			block = self.s.chain.latestBlockProduced()
+			if block == -1:
+				startingRoundBlock = session
+				currentBlock = self.s.chain.getHeight()
+				blocksToCheck = [b for b in self.s.chain.getExpectedBlocks() if b <= currentBlock and (self.lastBlockChecked is None or b > self.lastBlockChecked) and b >= startingRoundBlock]
+				for b in blocksToCheck:
+					a = self.s.chain.getBlockAuthor(b)
+					collator = self.s.conf.getOrDefault('chain.validatorAddress')
+					if a.lower() == collator.lower():
+						self.oc += 1
+					self.lastBlockChecked = b
+					self.totalBlockChecked += 1
 
-        if self.prev != session:
-            self.prev = session
-            report = f'{self.oc} block produced last session'
-            if self.totalBlockChecked > 0:
-                report = f'{report} out of {self.totalBlockChecked} ({self.oc / self.totalBlockChecked * 100:.2f} %)'
-                self.totalBlockChecked = 0
-            report = f'{report} {Emoji.BlockProd}'
-            self.oc = 0
-            if self.s.chain.isValidator():
-                return self.notify(f'will validate during the session {session + 1} {Emoji.Leader}\n{report}')
-            elif block != -1:
-                return self.notify(f'will not validate during the session {session + 1} {Emoji.NoLeader}\n{report}')
-            else:
-                return self.notify(report)
-        return False
+		if self.prev != session:
+			self.s.persistent.timedAdd(self.name + '_sessionBlocksProduced', self.prev)
+			self.s.persistent.timedAdd(self.name + '_blocksChecked', self.totalBlockChecked)
+			self.prev = session
+			report = f'{self.oc} block produced last session'
+			perc = 0
+			if self.totalBlockChecked > 0:
+				perc = self.oc / self.totalBlockChecked * 100
+				report = f'{report} out of {self.totalBlockChecked} ({perc:.2f} %)'
+				self.totalBlockChecked = 0
+			report = f'{report} {Emoji.BlockProd}'
+			self.s.persistent.timedAdd(self.name + '_blocksProduced', self.oc)
+			self.s.persistent.timedAdd(self.name + '_blocksPercentageProduced', perc)
+			self.oc = 0
+			if self.s.chain.isValidator():
+				return self.notify(f'will validate during the session {session + 1} {Emoji.Leader}\n{report}')
+			elif block != -1:
+				return self.notify(f'will not validate during the session {session + 1} {Emoji.NoLeader}\n{report}')
+			else:
+				return self.notify(report)
+		return False
 
 class Amplitude(Substrate):
-    TYPE = "parachain"
-    CUSTOM_TASKS = [TaskRelayChainStuck, TaskBlockProductionReportParachain]
+	TYPE = "parachain"
+	CUSTOM_TASKS = [TaskRelayChainStuck, TaskBlockProductionReportParachain]
 
-    def __init__(self, conf):
-        super().__init__(conf)
+	def __init__(self, conf):
+		super().__init__(conf)
 
-    @staticmethod
-    def detect(conf):
-        try:
-            Amplitude(conf).getVersion()
-            return Amplitude(conf).isParachain()
-        except:
-            return False
+	@staticmethod
+	def detect(conf):
+		try:
+			Amplitude(conf).getVersion()
+			return Amplitude(conf).isParachain()
+		except:
+			return False
 
-    def getSession(self):
-        si = self.getSubstrateInterface()
-        result = si.query(module='Session', storage_function='CurrentIndex', params=[])
-        return result.value
+	def getSession(self):
+		si = self.getSubstrateInterface()
+		result = si.query(module='Session', storage_function='CurrentIndex', params=[])
+		return result.value
 
-    def isCollating(self):
-        collator = self.conf.getOrDefault('chain.validatorAddress')
-        if collator:
-            si = self.getSubstrateInterface()
-            result = si.query(module='ParachainStaking', storage_function='TopCandidates', params=[])
-            for c in result.value:
-                if c["owner"].lower() == collator.lower():
-                    return True
-        return False
+	def isCollating(self):
+		collator = self.conf.getOrDefault('chain.validatorAddress')
+		if collator:
+			si = self.getSubstrateInterface()
+			result = si.query(module='ParachainStaking', storage_function='TopCandidates', params=[])
+			for c in result.value:
+				if c["owner"].lower() == collator.lower():
+					return True
+		return False

--- a/srvcheck/chains/astar.py
+++ b/srvcheck/chains/astar.py
@@ -91,7 +91,7 @@ class Astar(Substrate):
 	def detect(conf):
 		try:
 			Astar(conf).getVersion()
-			return Astar(conf).isParachain() and int(Astar(conf).getParachainId()) == int(conf.getOrDefault('chain.parachainId'))
+			return Astar(conf).isParachain() and Astar(conf).getNodeName() == "Astar Collator"
 		except:
 			return False
 

--- a/srvcheck/chains/astar.py
+++ b/srvcheck/chains/astar.py
@@ -4,6 +4,27 @@ from .substrate import Substrate
 from .substrate import TaskRelayChainStuck, TaskBlockProductionReportCharts
 from ..notification import Emoji
 
+class TaskBlockProductionCheck(Task):
+	def __init__(self, services, checkEvery=minutes(30), notifyEvery=minutes(30)):
+		super().__init__('TaskBlockProductionCheck',
+			  services, checkEvery, notifyEvery)
+		self.prev = None
+
+	@staticmethod
+	def isPluggable(services):
+		return services.chain.isParachain()
+
+	def run(self):
+		if self.s.chain.isCollating():
+			block = self.s.chain.latestBlockProduced()
+			if block > 0:
+				if self.prev is None:
+					self.prev = block
+				elif self.prev == block:
+					return self.notify(f'no block produced in the latest 30 minutes! Last block produced was {self.prev} {Emoji.BlockMiss}')
+				self.prev = block
+		return False
+
 class TaskBlockProductionReportParachain(Task):
 	def __init__(self, services, checkEvery=minutes(10), notifyEvery=hours(1)):
 		super().__init__('TaskBlockProductionReportParachain',
@@ -24,17 +45,18 @@ class TaskBlockProductionReportParachain(Task):
 		if self.prev is None:
 			self.prev = session
 
+		block = 0
 		if self.s.chain.isCollating():
-			startingRoundBlock = session
-			currentBlock = self.s.chain.getHeight()
-			blocksToCheck = [b for b in self.s.chain.getExpectedBlocks() if b <= currentBlock and (self.lastBlockChecked is None or b > self.lastBlockChecked) and b >= startingRoundBlock]
-			for b in blocksToCheck:
-				a = self.s.chain.getBlockAuthor(b)
-				collator = self.s.conf.getOrDefault('chain.validatorAddress')
-				if a.lower() == collator.lower():
+			block = self.s.chain.latestBlockProduced()
+			if block > 0:
+				if self.prevBlock is None:
+					self.prevBlock = block
 					self.oc += 1
-				self.lastBlockChecked = b
-				self.totalBlockChecked += 1
+
+				if block != self.prevBlock:
+					self.oc += 1
+
+				self.prevBlock = block
 
 		if self.prev != session:
 			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_sessionBlocksProduced', self.prev)
@@ -52,13 +74,15 @@ class TaskBlockProductionReportParachain(Task):
 			self.oc = 0
 			if self.s.chain.isValidator():
 				return self.notify(f'will validate during the session {session + 1} {Emoji.Leader}\n{report}')
-			else:
+			elif block != -1:
 				return self.notify(f'will not validate during the session {session + 1} {Emoji.NoLeader}\n{report}')
+			else:
+				return self.notify(report)
 		return False
 
 class Amplitude(Substrate):
 	TYPE = "parachain"
-	CUSTOM_TASKS = [TaskRelayChainStuck, TaskBlockProductionReportParachain, TaskBlockProductionReportCharts]
+	CUSTOM_TASKS = [TaskRelayChainStuck, TaskBlockProductionReportParachain, TaskBlockProductionReportCharts, TaskBlockProductionCheck]
 
 	def __init__(self, conf):
 		super().__init__(conf)
@@ -75,8 +99,23 @@ class Amplitude(Substrate):
 		collator = self.conf.getOrDefault('chain.validatorAddress')
 		if collator:
 			si = self.getSubstrateInterface()
-			result = si.query(module='ParachainStaking', storage_function='TopCandidates', params=[])
+			result = si.query(module='CollatorSelection', storage_function='Candidates', params=[])
 			for c in result.value:
-				if c["owner"].lower() == collator.lower():
+				if c['who'].lower() == f'{collator}'.lower():
+					return True
+			result = si.query(module='CollatorSelection', storage_function='Invulnerables', params=[])
+			for c in result.value:
+				if c.lower() == f'{collator}'.lower():
 					return True
 		return False
+
+	def latestBlockProduced(self):
+		collator = self.conf.getOrDefault('chain.validatorAddress')
+		if collator:
+			si = self.getSubstrateInterface()
+			result = si.query(module='CollatorSelection', storage_function='LastAuthoredBlock', params=[collator])
+			return result.value
+		return 0
+
+	def getBlockAuthor(self, block):
+		return self.rpcCall('eth_getBlockByNumber', [hex(block), True])['author']

--- a/srvcheck/chains/astar.py
+++ b/srvcheck/chains/astar.py
@@ -106,6 +106,3 @@ class Astar(Substrate):
 			result = si.query(module='CollatorSelection', storage_function='LastAuthoredBlock', params=[collator])
 			return result.value
 		return 0
-
-	def getBlockAuthor(self, block):
-		return self.rpcCall('eth_getBlockByNumber', [hex(block), True])['author']

--- a/srvcheck/chains/astar.py
+++ b/srvcheck/chains/astar.py
@@ -80,7 +80,7 @@ class TaskBlockProductionReportParachain(Task):
 				return self.notify(report)
 		return False
 
-class Amplitude(Substrate):
+class Astar(Substrate):
 	TYPE = "parachain"
 	CUSTOM_TASKS = [TaskRelayChainStuck, TaskBlockProductionReportParachain, TaskBlockProductionReportCharts, TaskBlockProductionCheck]
 
@@ -90,8 +90,8 @@ class Amplitude(Substrate):
 	@staticmethod
 	def detect(conf):
 		try:
-			Amplitude(conf).getVersion()
-			return Amplitude(conf).isParachain() and Amplitude(conf).getParachainId() == conf.getOrDefault('chain.parachainId')
+			Astar(conf).getVersion()
+			return Astar(conf).isParachain() and int(Astar(conf).getParachainId()) == int(conf.getOrDefault('chain.parachainId'))
 		except:
 			return False
 

--- a/srvcheck/chains/mangata.py
+++ b/srvcheck/chains/mangata.py
@@ -1,53 +1,5 @@
-from srvcheck.tasks.task import hours, minutes
-from ..tasks import Task
 from .substrate import Substrate
-from .substrate import TaskRelayChainStuck, TaskBlockProductionReportCharts
-
-class TaskBlockProductionReportParachain(Task):
-	def __init__(self, services, checkEvery=minutes(10), notifyEvery=hours(1)):
-		super().__init__('TaskBlockProductionReportParachain',
-                    services, checkEvery, notifyEvery)
-		self.prev = None
-		self.prevBlock = None
-		self.lastBlockChecked = None
-		self.totalBlockChecked = 0
-		self.oc = 0
-
-	@staticmethod
-	def isPluggable(services):
-		return services.chain.isParachain()
-
-	def run(self):
-		s = self.s.chain.getSession()
-		session = s['current']
-        
-		if self.prev is None:
-			self.prev = session
-
-		if self.s.chain.isCollating():
-			startingRoundBlock = s['first']
-			currentBlock = self.s.chain.getHeight()
-			blocksToCheck = [b for b in self.s.chain.getExpectedBlocks() if b <= currentBlock and (self.lastBlockChecked is None or b > self.lastBlockChecked) and b >= startingRoundBlock]
-			for b in blocksToCheck:
-				a = self.s.chain.getBlockAuthor(b)
-				collator = self.s.conf.getOrDefault('chain.validatorAddress')
-				if a.lower() == collator.lower():
-					self.oc += 1
-				self.lastBlockChecked = b
-				self.totalBlockChecked += 1
-
-		if self.prev != session:
-			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_sessionBlocksProduced', self.prev)
-			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_blocksChecked', self.totalBlockChecked)
-			self.prev = session
-			perc = 0
-			if self.totalBlockChecked > 0:
-				perc = self.oc / self.totalBlockChecked * 100
-				self.totalBlockChecked = 0
-			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_blocksProduced', self.oc)
-			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_blocksPercentageProduced', perc)
-			self.oc = 0
-		return False
+from .substrate import TaskRelayChainStuck, TaskBlockProductionReportParachain, TaskBlockProductionReportCharts
 
 class Mangata(Substrate):
 	TYPE = "parachain"
@@ -78,3 +30,10 @@ class Mangata(Substrate):
 				if c.lower() == collator.lower():
 					return True
 		return False
+
+	def getSessionWrapped(self):
+		return self.getSession()['current']
+
+	def getStartingRoundBlock(self):
+		return self.getSession()['first']
+		

--- a/srvcheck/chains/mangata.py
+++ b/srvcheck/chains/mangata.py
@@ -2,7 +2,6 @@ from srvcheck.tasks.task import hours, minutes
 from ..tasks import Task
 from .substrate import Substrate
 from .substrate import TaskRelayChainStuck, TaskBlockProductionReportCharts
-from ..notification import Emoji
 
 class TaskBlockProductionReportParachain(Task):
 	def __init__(self, services, checkEvery=minutes(10), notifyEvery=hours(1)):
@@ -41,20 +40,13 @@ class TaskBlockProductionReportParachain(Task):
 			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_sessionBlocksProduced', self.prev)
 			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_blocksChecked', self.totalBlockChecked)
 			self.prev = session
-			report = f'{self.oc} block produced last session'
 			perc = 0
 			if self.totalBlockChecked > 0:
 				perc = self.oc / self.totalBlockChecked * 100
-				report = f'{report} out of {self.totalBlockChecked} ({perc:.2f} %)'
 				self.totalBlockChecked = 0
-			report = f'{report} {Emoji.BlockProd}'
 			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_blocksProduced', self.oc)
 			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_blocksPercentageProduced', perc)
 			self.oc = 0
-			if self.s.chain.isValidator():
-				return self.notify(f'will validate during the session {session + 1} {Emoji.Leader}\n{report}')
-			else:
-				return self.notify(f'will not validate during the session {session + 1} {Emoji.NoLeader}\n{report}')
 		return False
 
 class Mangata(Substrate):

--- a/srvcheck/chains/mangata.py
+++ b/srvcheck/chains/mangata.py
@@ -68,7 +68,7 @@ class Mangata(Substrate):
 	def detect(conf):
 		try:
 			Mangata(conf).getVersion()
-			return Mangata(conf).isParachain() and Mangata(conf).getParachainId() == conf.getOrDefault('chain.parachainId')
+			return Mangata(conf).isParachain() and int(Mangata(conf).getParachainId()) == int(conf.getOrDefault('chain.parachainId'))
 		except:
 			return False
 

--- a/srvcheck/chains/mangata.py
+++ b/srvcheck/chains/mangata.py
@@ -68,7 +68,7 @@ class Mangata(Substrate):
 	def detect(conf):
 		try:
 			Mangata(conf).getVersion()
-			return Mangata(conf).isParachain() and int(Mangata(conf).getParachainId()) == int(conf.getOrDefault('chain.parachainId'))
+			return Mangata(conf).isParachain() and Mangata(conf).getNodeName() == "Mangata Parachain Collator"
 		except:
 			return False
 

--- a/srvcheck/chains/moonbeam.py
+++ b/srvcheck/chains/moonbeam.py
@@ -74,7 +74,7 @@ class Moonbeam(Substrate):
 	def detect(conf):
 		try:
 			Moonbeam(conf).getVersion()
-			return Moonbeam(conf).isParachain() and Moonbeam(conf).getParachainId() == conf.getOrDefault('chain.parachainId')
+			return Moonbeam(conf).isParachain() and int(Moonbeam(conf).getParachainId()) == int(conf.getOrDefault('chain.parachainId'))
 		except:
 			return False
 

--- a/srvcheck/chains/moonbeam.py
+++ b/srvcheck/chains/moonbeam.py
@@ -32,7 +32,7 @@ class TaskBlockProductionReportParachain(Task):
 			blocksToCheck = [b for b in self.s.chain.getExpectedBlocks() if b <= currentBlock and (self.lastBlockChecked is None or b > self.lastBlockChecked) and b >= startingRoundBlock]
 			for b in blocksToCheck:
 				a = self.s.chain.getBlockAuthor(b)
-				collator = orb if orb != '0x0' and orb is not None else self.s.conf.getOrDefault('chain.validatorAddress')
+				collator = self.s.conf.getOrDefault('chain.validatorAddress')
 				if a.lower() == collator.lower():
 					self.oc += 1
 				self.lastBlockChecked = b

--- a/srvcheck/chains/moonbeam.py
+++ b/srvcheck/chains/moonbeam.py
@@ -1,54 +1,5 @@
-from srvcheck.tasks.task import hours, minutes
-from ..tasks import Task
 from .substrate import Substrate
-from .substrate import TaskRelayChainStuck, TaskBlockProductionReportCharts
-
-class TaskBlockProductionReportParachain(Task):
-	def __init__(self, services, checkEvery=minutes(10), notifyEvery=hours(1)):
-		super().__init__('TaskBlockProductionReportParachain',
-                    services, checkEvery, notifyEvery)
-		self.prev = None
-		self.prevBlock = None
-		self.lastBlockChecked = None
-		self.totalBlockChecked = 0
-		self.oc = 0
-
-	@staticmethod
-	def isPluggable(services):
-		return services.chain.isParachain()
-
-	def run(self):
-		s = self.s.chain.getSession()
-		session = s['current']
-        
-		if self.prev is None:
-			self.prev = session
-
-		orb = self.s.chain.moonbeamAssignedOrbiter()
-		if self.s.chain.isCollating():
-			startingRoundBlock = s['first']
-			currentBlock = self.s.chain.getHeight()
-			blocksToCheck = [b for b in self.s.chain.getExpectedBlocks() if b <= currentBlock and (self.lastBlockChecked is None or b > self.lastBlockChecked) and b >= startingRoundBlock]
-			for b in blocksToCheck:
-				a = self.s.chain.getBlockAuthor(b)
-				collator = self.s.conf.getOrDefault('chain.validatorAddress')
-				if a.lower() == collator.lower():
-					self.oc += 1
-				self.lastBlockChecked = b
-				self.totalBlockChecked += 1
-
-		if self.prev != session:
-			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_sessionBlocksProduced', self.prev)
-			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_blocksChecked', self.totalBlockChecked)
-			self.prev = session
-			perc = 0
-			if self.totalBlockChecked > 0:
-				perc = self.oc / self.totalBlockChecked * 100
-				self.totalBlockChecked = 0
-			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_blocksProduced', self.oc)
-			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_blocksPercentageProduced', perc)
-			self.oc = 0
-		return False
+from .substrate import TaskRelayChainStuck, TaskBlockProductionReportParachain, TaskBlockProductionReportCharts
 
 class Moonbeam(Substrate):
 	TYPE = "parachain"
@@ -100,3 +51,10 @@ class Moonbeam(Substrate):
 			result = si.query(module='MoonbeamOrbiters', storage_function='AccountLookupOverride', params=[collator])
 			return result.value
 		return "0x0"
+
+	def getSessionWrapped(self):
+		return self.getSession()['current']
+
+	def getStartingRoundBlock(self):
+		return self.getSession()['first']
+		

--- a/srvcheck/chains/moonbeam.py
+++ b/srvcheck/chains/moonbeam.py
@@ -74,7 +74,7 @@ class Moonbeam(Substrate):
 	def detect(conf):
 		try:
 			Moonbeam(conf).getVersion()
-			return Moonbeam(conf).isParachain() and int(Moonbeam(conf).getParachainId()) == int(conf.getOrDefault('chain.parachainId'))
+			return Moonbeam(conf).isParachain() and Moonbeam(conf).getNodeName() == "Moonbeam Parachain Collator"
 		except:
 			return False
 

--- a/srvcheck/chains/moonbeam.py
+++ b/srvcheck/chains/moonbeam.py
@@ -2,7 +2,6 @@ from srvcheck.tasks.task import hours, minutes
 from ..tasks import Task
 from .substrate import Substrate
 from .substrate import TaskRelayChainStuck, TaskBlockProductionReportCharts
-from ..notification import Emoji
 
 class TaskBlockProductionReportParachain(Task):
 	def __init__(self, services, checkEvery=minutes(10), notifyEvery=hours(1)):
@@ -42,25 +41,13 @@ class TaskBlockProductionReportParachain(Task):
 			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_sessionBlocksProduced', self.prev)
 			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_blocksChecked', self.totalBlockChecked)
 			self.prev = session
-			report = f'{self.oc} block produced last session'
 			perc = 0
 			if self.totalBlockChecked > 0:
 				perc = self.oc / self.totalBlockChecked * 100
-				report = f'{report} out of {self.totalBlockChecked} ({perc:.2f} %)'
 				self.totalBlockChecked = 0
-			report = f'{report} {Emoji.BlockProd}'
 			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_blocksProduced', self.oc)
 			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_blocksPercentageProduced', perc)
 			self.oc = 0
-			if self.s.chain.isValidator():
-				return self.notify(f'will validate during the session {session + 1} {Emoji.Leader}\n{report}')
-			elif orb != '0x0':
-				if orb is None:
-					return self.notify(f'is not the selected orbiter for the session {session + 1} {Emoji.NoOrbiter}\n{report}')
-				else:
-					return self.notify(f'is the selected orbiter for the session {session + 1} {Emoji.Orbiter}\n{report}')
-			else:
-				return self.notify(f'will not validate during the session {session + 1} {Emoji.NoLeader}\n{report}')
 		return False
 
 class Moonbeam(Substrate):

--- a/srvcheck/chains/substrate.py
+++ b/srvcheck/chains/substrate.py
@@ -258,10 +258,10 @@ class Substrate(Chain):
 					return True
 		return False
 
-	def getExpectedBlocks(self):
+	def getExpectedBlocks(self, since=60):
 		serv = self.conf.getOrDefault('chain.service')
 		if serv:
-			blocks = Bash(f"journalctl -u {serv} --no-pager --since '60 min ago' | grep -Eo 'Prepared block for proposing at [0-9]+' | sed 's/[^0-9]'//g").value().split("\n")
+			blocks = Bash(f"journalctl -u {serv} --no-pager --since '{since} min ago' | grep -Eo 'Prepared block for proposing at [0-9]+' | sed 's/[^0-9]'//g").value().split("\n")
 			blocks = [int(b) for b in blocks if b != '']
 			return blocks
 		return []

--- a/srvcheck/chains/substrate.py
+++ b/srvcheck/chains/substrate.py
@@ -6,7 +6,6 @@ from ..notification import Emoji
 from ..utils import ConfItem, ConfSet, Bash, savePlots, PlotsConf, SubPlotConf
 
 ConfSet.addItem(ConfItem('chain.validatorAddress', description='Validator address'))
-ConfSet.addItem(ConfItem('chain.parachainId', description='Parachain Id'))
 
 class TaskSubstrateNewReferenda(Task):
 	def __init__(self, services, checkEvery=hours(1), notifyEvery=60*10*60):
@@ -187,7 +186,7 @@ class Substrate(Chain):
 	def detect(conf):
 		try:
 			Substrate(conf).getVersion()
-			return conf.getOrDefault('chain.parachainId') is not None and not Substrate(conf).isParachain()
+			return not Substrate(conf).isParachain()
 		except:
 			return False
 
@@ -228,6 +227,9 @@ class Substrate(Chain):
 		si = self.getSubstrateInterface()
 		result = si.query(module='ParachainInfo', storage_function='ParachainId', params=[])
 		return result.value
+
+	def getNodeName(self):
+		return self.rpcCall('system_name')
 
 	def isParachain(self):
 		try:

--- a/srvcheck/chains/substrate.py
+++ b/srvcheck/chains/substrate.py
@@ -154,12 +154,6 @@ class TaskBlockProductionReportCharts(Task):
 		sp.data_mod = lambda y: y
 		sp.color = 'b'
 		
-		sp.label2 = 'Produced (%)'
-		sp.data2 = [100] * len(self.s.persistent.getN(self.s.conf.getOrDefault('chain.name') + '_blocksPercentageProduced', 30))
-		sp.data_mod2 = lambda y: y
-		sp.color2 = 'r'
-		
-		sp.share_y = True
 		sp.set_bottom_y = True
 		pc.subplots.append(sp)
 

--- a/srvcheck/chains/substrate.py
+++ b/srvcheck/chains/substrate.py
@@ -119,7 +119,7 @@ class TaskBlockProductionReportParachain(Task):
 			self.prev = session
 
 		if self.s.chain.isCollating():
-			startingRoundBlock = self.s.chain.getStartingBlock()
+			startingRoundBlock = self.s.chain.getStartingRoundBlock()
 			currentBlock = self.s.chain.getHeight()
 			blocksToCheck = [b for b in self.s.chain.getExpectedBlocks() if b <= currentBlock and (self.lastBlockChecked is None or b > self.lastBlockChecked) and b >= startingRoundBlock]
 			for b in blocksToCheck:

--- a/srvcheck/chains/substrate.py
+++ b/srvcheck/chains/substrate.py
@@ -270,7 +270,7 @@ class Substrate(Chain):
 		return self.checkAuthoredBlock(block)
 
 	def getSeals(self, block):
-		seals = Bash("grep -Eo 'Pre-sealed block for proposal at {}. Hash now 0x[0-9a-fA-F]+' /var/log/syslog | rev | cut -d ' ' -f1 | rev".format(block)).value().split("\n")
+		seals = Bash("grep -Eo 'block for proposal at {}. Hash now 0x[0-9a-fA-F]+' /var/log/syslog | rev | cut -d ' ' -f1 | rev".format(block)).value().split("\n")
 		return seals
 
 	def checkAuthoredBlock(self, block):

--- a/srvcheck/chains/substrate.py
+++ b/srvcheck/chains/substrate.py
@@ -6,6 +6,7 @@ from ..notification import Emoji
 from ..utils import ConfItem, ConfSet, Bash, savePlots, PlotsConf, SubPlotConf
 
 ConfSet.addItem(ConfItem('chain.validatorAddress', description='Validator address'))
+ConfSet.addItem(ConfItem('chain.parachainId', description='Parachain Id'))
 
 class TaskSubstrateNewReferenda(Task):
 	def __init__(self, services, checkEvery=hours(1), notifyEvery=60*10*60):

--- a/srvcheck/chains/t3rn.py
+++ b/srvcheck/chains/t3rn.py
@@ -1,0 +1,78 @@
+from srvcheck.tasks.task import hours, minutes
+from ..tasks import Task
+from .substrate import Substrate
+from .substrate import TaskRelayChainStuck, TaskBlockProductionReportCharts
+
+class TaskBlockProductionReportParachain(Task):
+	def __init__(self, services, checkEvery=minutes(10), notifyEvery=hours(1)):
+		super().__init__('TaskBlockProductionReportParachain',
+                    services, checkEvery, notifyEvery)
+		self.prev = None
+		self.prevBlock = None
+		self.lastBlockChecked = None
+		self.totalBlockChecked = 0
+		self.oc = 0
+		self.prevSessionLastBlock = 0
+
+	@staticmethod
+	def isPluggable(services):
+		return services.chain.isParachain()
+
+	def run(self):
+		session = self.s.chain.getSession()
+        
+		if self.prev is None:
+			self.prev = session
+
+		if self.s.chain.isCollating():
+			currentBlock = self.s.chain.getHeight()
+			blocksToCheck = [b for b in self.s.chain.getExpectedBlocks() if b <= currentBlock and (self.lastBlockChecked is None or b > self.lastBlockChecked)]
+			for b in blocksToCheck:
+				a = self.s.chain.getBlockAuthor(b)
+				collator = self.s.conf.getOrDefault('chain.validatorAddress')
+				if a.lower() == collator.lower():
+					self.oc += 1
+				self.lastBlockChecked = b
+				self.totalBlockChecked += 1
+
+		if self.prev != session:
+			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_sessionBlocksProduced', self.prev)
+			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_blocksChecked', self.totalBlockChecked)
+			self.prev = session
+			perc = 0
+			if self.totalBlockChecked > 0:
+				perc = self.oc / self.totalBlockChecked * 100
+				self.totalBlockChecked = 0
+			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_blocksProduced', self.oc)
+			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_blocksPercentageProduced', perc)
+			self.oc = 0
+		return False
+
+class T3rn(Substrate):
+	TYPE = "parachain"
+	CUSTOM_TASKS = [TaskRelayChainStuck, TaskBlockProductionReportParachain, TaskBlockProductionReportCharts]
+
+	def __init__(self, conf):
+		super().__init__(conf)
+
+	@staticmethod
+	def detect(conf):
+		try:
+			T3rn(conf).getVersion()
+			return T3rn(conf).isParachain() and T3rn(conf).getNodeName() == "Circuit Collator"
+		except:
+			return False
+
+	def isCollating(self):
+		collator = self.conf.getOrDefault('chain.validatorAddress')
+		if collator:
+			si = self.getSubstrateInterface()
+			result = si.query(module='CollatorSelection', storage_function='Candidates', params=[])
+			for c in result.value:
+				if c['who'].lower() == f'{collator}'.lower():
+					return True
+			result = si.query(module='CollatorSelection', storage_function='Invulnerables', params=[])
+			for c in result.value:
+				if c.lower() == f'{collator}'.lower():
+					return True
+		return False

--- a/srvcheck/chains/t3rn.py
+++ b/srvcheck/chains/t3rn.py
@@ -1,52 +1,5 @@
-from srvcheck.tasks.task import hours, minutes
-from ..tasks import Task
 from .substrate import Substrate
-from .substrate import TaskRelayChainStuck, TaskBlockProductionReportCharts
-
-class TaskBlockProductionReportParachain(Task):
-	def __init__(self, services, checkEvery=minutes(10), notifyEvery=hours(1)):
-		super().__init__('TaskBlockProductionReportParachain',
-                    services, checkEvery, notifyEvery)
-		self.prev = None
-		self.prevBlock = None
-		self.lastBlockChecked = None
-		self.totalBlockChecked = 0
-		self.oc = 0
-		self.prevSessionLastBlock = 0
-
-	@staticmethod
-	def isPluggable(services):
-		return services.chain.isParachain()
-
-	def run(self):
-		session = self.s.chain.getSession()
-        
-		if self.prev is None:
-			self.prev = session
-
-		if self.s.chain.isCollating():
-			currentBlock = self.s.chain.getHeight()
-			blocksToCheck = [b for b in self.s.chain.getExpectedBlocks() if b <= currentBlock and (self.lastBlockChecked is None or b > self.lastBlockChecked)]
-			for b in blocksToCheck:
-				a = self.s.chain.getBlockAuthor(b)
-				collator = self.s.conf.getOrDefault('chain.validatorAddress')
-				if a.lower() == collator.lower():
-					self.oc += 1
-				self.lastBlockChecked = b
-				self.totalBlockChecked += 1
-
-		if self.prev != session:
-			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_sessionBlocksProduced', self.prev)
-			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_blocksChecked', self.totalBlockChecked)
-			self.prev = session
-			perc = 0
-			if self.totalBlockChecked > 0:
-				perc = self.oc / self.totalBlockChecked * 100
-				self.totalBlockChecked = 0
-			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_blocksProduced', self.oc)
-			self.s.persistent.timedAdd(self.s.conf.getOrDefault('chain.name') + '_blocksPercentageProduced', perc)
-			self.oc = 0
-		return False
+from .substrate import TaskRelayChainStuck, TaskBlockProductionReportParachain, TaskBlockProductionReportCharts
 
 class T3rn(Substrate):
 	TYPE = "parachain"
@@ -76,3 +29,6 @@ class T3rn(Substrate):
 				if c.lower() == f'{collator}'.lower():
 					return True
 		return False
+
+	def getStartingRoundBlock(self):
+		return -1

--- a/srvcheck/main.py
+++ b/srvcheck/main.py
@@ -105,6 +105,7 @@ def main():
 				print ("Detected chain", chain.TYPE)
 				services = Services(conf, notification, system, chain, persistent)
 				tasks = addTasks(services)
+				print(tasks)
 				break
 
 	if not chain:

--- a/srvcheck/tasks/tasksystemusage.py
+++ b/srvcheck/tasks/tasksystemusage.py
@@ -28,7 +28,7 @@ class TaskSystemUsage(Task):
 
 		sp = SubPlotConf()
 		# sp.name = self.s.conf.getOrDefault('chain.name') + " - Disk"
-		sp.data = self.s.persistent.get(self.name + '_diskUsed')
+		sp.data = self.s.persistent.getN(self.name + '_diskUsed', 30)
 		sp.label = 'Used (GB)'
 		sp.data_mod = lambda y: toGB(y)
 		sp.color = 'b'
@@ -39,27 +39,27 @@ class TaskSystemUsage(Task):
 		pc.subplots.append(sp)
 
 		sp = SubPlotConf()
-		sp.data = self.s.persistent.get(self.name + '_diskPercentageUsed')
+		sp.data = self.s.persistent.getN(self.name + '_diskPercentageUsed', 30)
 		sp.label = 'Used (%)'
 		sp.data_mod = lambda y: y
 		sp.color = 'r'
 		pc.subplots.append(sp)
 
 		sp = SubPlotConf()
-		sp.data = self.s.persistent.get(self.name + '_diskUsedByLog')
+		sp.data = self.s.persistent.getN(self.name + '_diskUsedByLog', 30)
 		sp.label = 'Used by log (GB)'
 		sp.data_mod = lambda y: toGB(y)
 		sp.color = 'g'
 		pc.subplots.append(sp)
 
 		sp = SubPlotConf()
-		sp.data = self.s.persistent.get(self.name + '_ramUsed')
+		sp.data = self.s.persistent.getN(self.name + '_ramUsed', 30)
 		sp.label = 'Ram used (GB)'
 		sp.data_mod = lambda y: toGB(y)
 		sp.color = 'y'
 
 		sp.label2 = 'Ram size (GB)'
-		sp.data2 = self.s.persistent.get(self.name + '_ramSize')
+		sp.data2 = self.s.persistent.getN(self.name + '_ramSize', 30)
 		sp.data_mod2 = lambda y: toGB(y)
 		sp.color2 = 'r'
 
@@ -69,7 +69,7 @@ class TaskSystemUsage(Task):
 
 		pc.fpath = '/tmp/t.png'
 
-		if len(self.s.persistent.get(self.name + '_diskPercentageUsed')) >= 2:
+		if len(self.s.persistent.getN(self.name + '_diskPercentageUsed'), 30) >= 2:
 			savePlots(pc, 2, 2)
 			self.s.notification.sendPhoto('/tmp/t.png')
 

--- a/srvcheck/tasks/tasksystemusage.py
+++ b/srvcheck/tasks/tasksystemusage.py
@@ -69,7 +69,7 @@ class TaskSystemUsage(Task):
 
 		pc.fpath = '/tmp/t.png'
 
-		if len(self.s.persistent.getN(self.name + '_diskPercentageUsed'), 30) >= 2:
+		if len(self.s.persistent.getN(self.name + '_diskPercentageUsed', 30)) >= 2:
 			savePlots(pc, 2, 2)
 			self.s.notification.sendPhoto('/tmp/t.png')
 

--- a/srvcheck/utils/chart.py
+++ b/srvcheck/utils/chart.py
@@ -77,12 +77,17 @@ def savePlots(c, s1, s2):
 			
 		ax.plot(list(map(lambda l: (dateutil.parser.isoparse(l[0])), sp.data)),
 			list(map(lambda l: (sp.data_mod(l[1])), sp.data)), '-' + sp.color)
+		ax.fill_between(list(map(lambda l: (dateutil.parser.isoparse(l[0])), sp.data)),
+			list(map(lambda l: (sp.data_mod(l[1])), sp.data)), facecolor=setColor(sp.color), interpolate=True)
 
 		if sp.data2 and not sp.share_y:
 			ax2.plot(list(map(lambda l: (dateutil.parser.isoparse(l[0])), sp.data2)), list(map(lambda l: (sp.data_mod2(l[1])), sp.data2)), sp.color2 + '-')
+			ax2.fill_between(list(map(lambda l: (dateutil.parser.isoparse(l[0])), sp.data2)), list(map(lambda l: (sp.data_mod2(l[1])), sp.data2)), facecolor=setColor(sp.color2), interpolate=True)
 			ax2.set_ylabel(sp.label2, color=sp.color2)
 		elif sp.data2 and sp.share_y:
 			ax.plot(list(map(lambda l: (dateutil.parser.isoparse(l[0])), sp.data2)), list(map(lambda l: (sp.data_mod2(l[1])), sp.data2)), sp.color2 + '-')
+			ax.fill_between(list(map(lambda l: (dateutil.parser.isoparse(l[0])), sp.data2)), list(map(lambda l: (sp.data_mod2(l[1])), sp.data2)), facecolor=setColor(sp.color2), interpolate=True)
+			ax.fill_between(list(map(lambda l: (dateutil.parser.isoparse(l[0])), sp.data)), list(map(lambda l: (sp.data_mod(l[1])), sp.data)), facecolor=setColor(sp.color), interpolate=True)
 
 		# ax.set_xlabel('Date')
 		ax.set_ylabel(sp.label, color=sp.color)
@@ -93,3 +98,15 @@ def savePlots(c, s1, s2):
 		ax.xaxis.set_major_formatter(mdates.DateFormatter('%d/%m'))
 		ax.xaxis.set_major_locator(mdates.DayLocator(interval=5))
 	plt.savefig(c.fpath, bbox_inches="tight")
+
+def setColor(color):
+	if color == 'b':
+		return 'blue'
+	elif color == 'r':
+		return 'red'
+	elif color == 'y':
+		return 'yellow'
+	elif color == 'g':
+		return 'green'
+	else:
+		return 'none'

--- a/srvcheck/utils/chart.py
+++ b/srvcheck/utils/chart.py
@@ -78,16 +78,16 @@ def savePlots(c, s1, s2):
 		ax.plot(list(map(lambda l: (dateutil.parser.isoparse(l[0])), sp.data)),
 			list(map(lambda l: (sp.data_mod(l[1])), sp.data)), '-' + sp.color)
 		ax.fill_between(list(map(lambda l: (dateutil.parser.isoparse(l[0])), sp.data)),
-			list(map(lambda l: (sp.data_mod(l[1])), sp.data)), facecolor=setColor(sp.color), interpolate=True)
+			list(map(lambda l: (sp.data_mod(l[1])), sp.data)), facecolor=setColor(sp.color), interpolate=True, alpha=.3)
 
 		if sp.data2 and not sp.share_y:
 			ax2.plot(list(map(lambda l: (dateutil.parser.isoparse(l[0])), sp.data2)), list(map(lambda l: (sp.data_mod2(l[1])), sp.data2)), sp.color2 + '-')
-			ax2.fill_between(list(map(lambda l: (dateutil.parser.isoparse(l[0])), sp.data2)), list(map(lambda l: (sp.data_mod2(l[1])), sp.data2)), facecolor=setColor(sp.color2), interpolate=True)
+			ax2.fill_between(list(map(lambda l: (dateutil.parser.isoparse(l[0])), sp.data2)), list(map(lambda l: (sp.data_mod2(l[1])), sp.data2)), facecolor=setColor(sp.color2), interpolate=True, alpha=.3)
 			ax2.set_ylabel(sp.label2, color=sp.color2)
 		elif sp.data2 and sp.share_y:
 			ax.plot(list(map(lambda l: (dateutil.parser.isoparse(l[0])), sp.data2)), list(map(lambda l: (sp.data_mod2(l[1])), sp.data2)), sp.color2 + '-')
-			ax.fill_between(list(map(lambda l: (dateutil.parser.isoparse(l[0])), sp.data2)), list(map(lambda l: (sp.data_mod2(l[1])), sp.data2)), facecolor=setColor(sp.color2), interpolate=True)
-			ax.fill_between(list(map(lambda l: (dateutil.parser.isoparse(l[0])), sp.data)), list(map(lambda l: (sp.data_mod(l[1])), sp.data)), facecolor=setColor(sp.color), interpolate=True)
+			ax.fill_between(list(map(lambda l: (dateutil.parser.isoparse(l[0])), sp.data2)), list(map(lambda l: (sp.data_mod2(l[1])), sp.data2)), facecolor=setColor(sp.color2), interpolate=True, alpha=.8)
+			ax.fill_between(list(map(lambda l: (dateutil.parser.isoparse(l[0])), sp.data)), list(map(lambda l: (sp.data_mod(l[1])), sp.data)), facecolor=setColor(sp.color), interpolate=True, alpha=.8)
 
 		# ax.set_xlabel('Date')
 		ax.set_ylabel(sp.label, color=sp.color)
@@ -101,12 +101,12 @@ def savePlots(c, s1, s2):
 
 def setColor(color):
 	if color == 'b':
-		return 'blue'
+		return '#58508d'
 	elif color == 'r':
-		return 'red'
+		return '#ff6361'
 	elif color == 'y':
-		return 'yellow'
+		return '#ffa600'
 	elif color == 'g':
-		return 'green'
+		return '#558f4c'
 	else:
 		return 'none'

--- a/srvcheck/utils/chart.py
+++ b/srvcheck/utils/chart.py
@@ -50,6 +50,7 @@ class SubPlotConf:
 		self.data_mod2 = lambda y: y
 
 		self.share_y = False
+		self.set_bottom_y = False
 
 class PlotsConf:
 	def __init__(self):
@@ -85,6 +86,9 @@ def savePlots(c, s1, s2):
 
 		# ax.set_xlabel('Date')
 		ax.set_ylabel(sp.label, color=sp.color)
+
+		if sp.set_bottom_y:
+			ax.set_ylim(bottom=0)
 
 		ax.xaxis.set_major_formatter(mdates.DateFormatter('%d/%m'))
 		ax.xaxis.set_major_locator(mdates.DayLocator(interval=5))

--- a/srvcheck/utils/persistent.py
+++ b/srvcheck/utils/persistent.py
@@ -25,6 +25,11 @@ class Persistent:
 			return self.data[k]
 		return None
 
+	def getN(self, k, n):
+		if k in self.data:
+			return self.data[k][-n:]
+		return None
+
 	def timedAdd(self, k, v):
 		if k not in self.data:
 			self.data[k] = []


### PR DESCRIPTION
Changed the way the software handles **polkadot** and **kusama** **_parachains_**, the software now uses a **modular** approach that makes easier to support all the features of the software on a new parachain.
The _parachains_ that have been added are: **Amplitude**, **Astar/Shiden/Shibuya**, **Mangata**, **Moonbeam/Moonriver/Moonbase**, **T3rn/T0rn**

Added and modified tasks for the monitoring of the performance of _**Substrate**_ nodes:
- **TaskBlockProductionReport** and **TaskBlockProductionReportParachain**, used to monitor the performance of a standard Substrate and parachain node in terms of block produced and missed in the previous era/session, these tasks were too verbose, now these only save the data about block production on a file that is used by a new task called **TaskBlockProductionReportCharts** which will send the charts via photo giving a better overview in general about the performances and reducing the verbosity (these charts are sent one time per day) (Close #105)

**Bugs** fixed and misc **changes**:
- Fixed the issue with the newer versions of the **packaging** python module (Close #111)
- Added the logic to handle the param **--endpoint** to the installer that allows to specify a custom endpoint of the node directly when installing the **srvcheck**
- Fixed **systemusage** _charts_ using the new function **getN()** to fetch only the N last data from the file that has the persistent data stored